### PR TITLE
[New] cluster nodes probe

### DIFF
--- a/cmd/cli/command/clustershow.go
+++ b/cmd/cli/command/clustershow.go
@@ -32,7 +32,7 @@ type ShowNode struct {
 	GitSha1  string
 	Addr     string
 	Slots    string
-	Epoch    uint64
+	Epoch    int64
 	Connectd string
 	Repl     string
 	Clients  string

--- a/cmd/cli/command/dirchange.go
+++ b/cmd/cli/command/dirchange.go
@@ -20,17 +20,19 @@ var CdCommand = cli.Command{
 }
 
 func cdAction(c *cli.Context) {
-	ctx := context.GetContext()
-	name := ctx.CdName
+	if len(c.Args()) == 0 {
+		return 
+	}
+	name := c.Args()[0]
 	if len(name) == 0 {
 		return
 	}
-
+	ctx := context.GetContext()
 	if name == ".." {
 		ctx.Outside()
 		return
 	}
-
+	
 	switch ctx.Location {
 	case context.LocationRoot:
 		resp, err := util.HttpGet(handlers.GetNamespaceRootURL(ctx.Leader), nil, 5 * time.Second)

--- a/cmd/cli/command/namespacemake.go
+++ b/cmd/cli/command/namespacemake.go
@@ -22,20 +22,21 @@ var MakeNsCommand = cli.Command{
 }
 
 func mknsAction(c *cli.Context) {
+	if len(c.Args()) != 1 {
+		fmt.Println("mkns only set one param(${namespace})")
+		return 
+	}
+	name := c.Args()[0]
+	if strings.Contains(name, "/") {
+		fmt.Println("namespcae can't contain '/'")
+		return 
+	}
 	ctx := context.GetContext()
 	if ctx.Location != context.LocationRoot {
 		fmt.Println("mkns need return root dir '/'")
 		return 
 	}
-	if len(ctx.MknsName) == 0 {
-		fmt.Println("mkns need set namespcae")
-		return 
-	}
-	if strings.Contains(ctx.MknsName, "/") {
-		fmt.Println("namespcae can't contain '/'")
-		return 
-	}
-	name := ctx.MknsName
+	
 	resp, err := util.HttpPost(handlers.GetNamespaceRootURL(ctx.Leader), handlers.CreateNamespaceParam{Namespace: name,}, 5 * time.Second)
 	if HttpResponeException("make namespcae", resp, err) {
 		return

--- a/cmd/cli/command/redisdo.go
+++ b/cmd/cli/command/redisdo.go
@@ -5,7 +5,6 @@ import (
 	"context"
 
 	"gopkg.in/urfave/cli.v1"
-	clictx "github.com/KvrocksLabs/kvrocks-controller/cmd/cli/context"
 	"github.com/KvrocksLabs/kvrocks-controller/util"
 )
 
@@ -20,13 +19,12 @@ var RedisDoCommand = cli.Command{
 }
 
 func doAction(c *cli.Context) {
-    args := clictx.GetContext().ReidsArgs
-    if len(args) < 2 {
+    if len(c.Args()) < 2 {
     	fmt.Println("do command at least 2 params")
     	return 
     }
-    node := args[0]
-    args = args[1:]
+    node := c.Args()[0]
+    args := c.Args()[1:]
     var redisArgs []interface{}
     for _, arg := range args {
     	redisArgs = append(redisArgs, arg)

--- a/cmd/cli/command/redispdo.go
+++ b/cmd/cli/command/redispdo.go
@@ -22,20 +22,18 @@ var RedisPdoCommand = cli.Command{
 }
 
 func pdoAction(c *cli.Context) {
+	if len(c.Args()) < 1 {
+    	fmt.Println("do command at least 1 params")
+    	return 
+    }
 	ctx := clictx.GetContext()
 	if ctx.Location != clictx.LocationCluster {
 		fmt.Println("pdo command should under clsuter dir")
 		return 
 	}
-
-	// parser args
-    args := clictx.GetContext().ReidsArgs
-    if len(args) < 1 {
-    	fmt.Println("do command at least 1 params")
-    	return 
-    }
+    
     var redisArgs []interface{}
-    for _, arg := range args {
+    for _, arg := range c.Args() {
     	redisArgs = append(redisArgs, arg)
     }
 

--- a/cmd/cli/context/context.go
+++ b/cmd/cli/context/context.go
@@ -46,9 +46,6 @@ type Context struct {
 	Location    int
 	Namespace   string
 	Cluster     string
-	CdName 		string
-	MknsName 	string
-	ReidsArgs   []string
 }
 
 var context *Context

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -120,32 +120,6 @@ func showHelp() {
 	}
 }
 
-func handlCmd(cmd string, fields []string) bool {
-	switch cmd {
-	case "cd":
-		if len(fields) > 1 {
-			ctx.CdName = fields[1]
-		} else {
-			ctx.CdName = ""
-		}
-	case "mkns":
-		if len(fields) == 2 {
-			ctx.MknsName = fields[1]
-		} else if len(fields) > 2 {
-			fmt.Println("mkns need set only one param ${namespcae}")
-			ctx.MknsName = ""
-			return false
-		} else if len(fields) < 2 {
-			return false
-		}
-	case "do":
-		ctx.ReidsArgs = fields[1:]
-	case "pdo":
-		ctx.ReidsArgs = fields[1:]
-	}
-	return true
-}
-
 func main() {
 	//load config
 	user, err := user.Current()
@@ -219,9 +193,6 @@ func main() {
 		cmd, ok := cmdmap[fields[0]]
 		if !ok {
 			fmt.Println("Error: unknown command.")
-			continue
-		}
-		if !handlCmd(cmd.Name, fields) {
 			continue
 		}
 		app := cli.NewApp()

--- a/controller/healthprobe.go
+++ b/controller/healthprobe.go
@@ -1,0 +1,112 @@
+package controller
+
+import (
+	"sync"
+
+	"github.com/KvrocksLabs/kvrocks-controller/util"
+	"github.com/KvrocksLabs/kvrocks-controller/storage"
+)
+
+// HealthProbe manager all clusters probe
+type HealthProbe struct {
+	stor   *storage.Storage
+	probes map[string]*Probe
+    ready  bool
+
+	rw        sync.RWMutex
+	quitCh    chan struct{}
+	closeOnce sync.Once
+}
+
+// NewHealthProbe return HealthProbe contain all methods to manager probe
+func NewHealthProbe(stor *storage.Storage)*HealthProbe {
+	hp := &HealthProbe{
+		stor:   stor,
+		probes: make(map[string]*Probe),
+		quitCh: make(chan struct{}),
+	}
+	return hp
+}
+
+// LoadData start exist clusters probe goroutine
+func(hp *HealthProbe) LoadData() error {
+	hp.rw.Lock()
+	defer hp.rw.Unlock()
+	namespaces, err := hp.stor.ListNamespace()
+	if err != nil {
+		return err
+	}
+
+	probes := make(map[string]*Probe)
+	for _, namespace :=range namespaces {
+		clusters, err := hp.stor.ListCluster(namespace)
+		if err != nil {
+			return err
+		}
+		for _, cluster :=range clusters {
+			probes[util.NsClusterJoin(namespace, cluster)] = NewProbe(namespace, cluster, hp.stor)
+		}
+	}
+	for _, probe :=range probes {
+		probe.start()
+	}
+	hp.probes = probes
+	hp.ready = true
+	return nil
+}
+
+// Close implement io.Close interface
+func(hp *HealthProbe) Close() error {
+	hp.rw.Lock()
+	defer hp.rw.Unlock()
+	hp.closeOnce.Do(func() {
+		close(hp.quitCh)
+	})
+	return nil
+}
+
+// Stop all cluster probe when leader-follower switch
+func(hp *HealthProbe) Stop() {
+	hp.rw.Lock()
+	defer hp.rw.Unlock()
+	if !hp.ready {
+		return 
+	}
+	hp.ready = false
+	for _, probe :=range hp.probes {
+		probe.stop()
+	}
+	return
+}
+
+// AddCluster add cluster probe and start 
+func(hp *HealthProbe) AddCluster(ns, cluster string) {
+	hp.rw.Lock()
+	defer hp.rw.Unlock()
+	if !hp.ready {
+		return 
+	}
+	if _, ok := hp.probes[util.NsClusterJoin(ns, cluster)]; ok {
+		return 
+	}
+	probe := NewProbe(ns, cluster, hp.stor)
+	probe.start()
+	hp.probes[util.NsClusterJoin(ns, cluster)] = probe
+	return
+}
+
+// RemoveCluster delete cluster probe and stop 
+func(hp *HealthProbe) RemoveCluster(ns, cluster string) {
+	hp.rw.Lock()
+	defer hp.rw.Unlock()
+	if !hp.ready {
+		return
+	}
+	if probe, ok := hp.probes[util.NsClusterJoin(ns, cluster)]; !ok {
+		return 
+	} else {
+		probe.stop()
+	}
+	delete(hp.probes, util.NsClusterJoin(ns, cluster))
+	return 
+}

--- a/controller/probe.go
+++ b/controller/probe.go
@@ -1,0 +1,156 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+	"errors"
+
+	"go.uber.org/zap"
+	"github.com/KvrocksLabs/kvrocks-controller/util"
+	"github.com/KvrocksLabs/kvrocks-controller/logger"
+	"github.com/KvrocksLabs/kvrocks-controller/storage"
+)
+var (
+	// ErrClustrerDown return from kvnodes
+	ErrClustrerDown = errors.New("CLUSTERDOWN The cluster is not initialized")
+)
+
+var (
+	// probe interval
+	ProbeInterval = 1
+
+	// statis interval for probe
+	ProbeCycle    = 60
+)
+
+// Probe manager cluster schedule
+type Probe struct {
+	namespace string
+	cluster   string
+	stor      *storage.Storage
+
+	stopCh chan struct{}
+}
+
+// NewProbe return Probe stands cluster probe
+func NewProbe(ns, cluster string, stor *storage.Storage) *Probe{
+	return &Probe{
+		namespace: ns,
+		cluster:   cluster,
+		stor:      stor,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// start goroutine to probe cluster nodes
+func(p *Probe) start() {
+	go p.probe()
+}
+
+// NodeInfo record node probe info
+type NodeInfo struct {
+	id   string
+	addr string
+}
+
+// probe logic
+func(p *Probe) probe() {
+	probeCount := 0
+	probeTicker := time.NewTimer(time.Duration(ProbeInterval) * time.Second)
+	defer probeTicker.Stop()
+	for {
+		select {
+		case <-probeTicker.C:
+			probeCount++
+			var (
+				allNodes    = 0
+				nomalNodes  = 0
+				behindNodes = 0
+				aheadNodes  = 0
+			)
+			probeInfos := make(map[int64][]*NodeInfo)
+			cluster, err := p.stor.GetClusterCopy(p.namespace, p.cluster)
+			if err != nil {
+				logger.Get().With(
+		    		zap.Error(err),
+		    	).Error("get cluster form local error")
+		    	// TODO: push failover queue
+		    	// if err.Error() != ErrClustrerDown.Error() {
+		    	// }
+		    	break
+			}
+			for _, shard := range cluster.Shards {
+				for _, node := range shard.Nodes {
+					allNodes++
+					info, err := util.ClusterInfoCmd(node.Address)
+					if err != nil {
+						logger.Get().With(
+				    		zap.Error(err),
+				    	).Error("get cluster form local error")
+					} else {
+						probeInfos[info.ClusterMyEpoch] = append(probeInfos[info.ClusterMyEpoch], 
+							&NodeInfo{
+								id:   node.ID,
+								addr: node.Address,
+							})
+					}
+				}
+			}
+
+			// access newest cluster topo
+			clusterNewest, err := p.stor.GetClusterCopy(p.namespace, p.cluster)
+			if err != nil {
+				logger.Get().With(
+		    		zap.Error(err),
+		    	).Error("get cluster form local error")
+			} else {
+				cluster = clusterNewest
+			}
+			clusterVer := cluster.Version
+			clusterStr, err := cluster.ToSlotString()
+			if err != nil {
+				logger.Get().With(
+		    		zap.Error(err),
+		    	).Error("cluster info to string error")
+				break
+			}
+			for ver, nodes := range probeInfos {
+				if ver == clusterVer {
+					nomalNodes += len(nodes)
+					continue
+				}
+				if ver > clusterVer {
+					aheadNodes += len(nodes)
+					logger.Get().With(
+						zap.Any("node", nodes),
+					).Warn("node version ahead")
+					continue
+				}
+				behindNodes += len(nodes)
+				logger.Get().With(
+						zap.Any("node", nodes),
+					).Warn("node version behind")
+				for _, node := range nodes {
+					if err := util.SyncClusterInfo2Node(node.addr, node.id, clusterStr, clusterVer); err != nil {
+						logger.Get().With(
+				    		zap.Error(err),
+				    	).Error("sync cluster info to node error " + node.addr)
+					}
+				}
+			}
+			if probeCount % ProbeCycle == 0 {
+				logInfo := fmt.Sprintf("%s probe info, all: %d, nomal: %d, ahead: %d, behind: %d",
+						util.NsClusterJoin(p.namespace, p.cluster), allNodes, nomalNodes, aheadNodes, behindNodes)
+				logger.Get().Info(logInfo)
+			}
+		case <-p.stopCh:
+			return
+		}
+		probeTicker.Reset(time.Duration(ProbeInterval) * time.Second)
+	}
+}
+
+// stop cluster probe
+func(p *Probe) stop() {
+	close(p.stopCh)
+}

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -1,0 +1,9 @@
+package util
+
+import (
+	"github.com/KvrocksLabs/kvrocks-controller/storage/base/etcd"
+)
+
+func NsClusterJoin(ns, cluster string) string {
+	return ns + etcd.Delimiter + cluster
+}

--- a/util/redis_command.go
+++ b/util/redis_command.go
@@ -14,8 +14,8 @@ type ClusterInfo struct {
 	ClusterSlotsFail     int 
 	ClusterKnownNodes    int
 	ClusterSize          int 
-	ClusterCurrentEpoch  uint64
-	ClusterMyEpoch       uint64
+	ClusterCurrentEpoch  int64
+	ClusterMyEpoch       int64
 	MigratingSlot        int 
 	ImportingSlot        int
 	DestinationNode      string
@@ -65,9 +65,9 @@ func ClusterInfoCmd(nodeAddr string) (*ClusterInfo, error) {
 		case "cluster_size":
 			clusterInfo.ClusterSize, _ = strconv.Atoi(val)
 		case "cluster_current_epoch":
-			clusterInfo.ClusterCurrentEpoch, _ = strconv.ParseUint(val, 10, 64)
+			clusterInfo.ClusterCurrentEpoch, _ = strconv.ParseInt(val, 10, 64)
 		case "cluster_my_epoch":
-			clusterInfo.ClusterMyEpoch, _ = strconv.ParseUint(val, 10, 64)
+			clusterInfo.ClusterMyEpoch, _ = strconv.ParseInt(val, 10, 64)
 		case "migrating_slot":
 			clusterInfo.MigratingSlot, _ = strconv.Atoi(val)
 		case "importing_slot":
@@ -274,4 +274,20 @@ func NodeInfoCmd(nodeAddr string) (*NodeInfo, error){
 		}
 	}
 	return nodeInfo, nil
+}
+
+func SyncClusterInfo2Node(nodeAddr, nodeID , clusterStr string, ver int64) error {
+	cli, err := RedisPool(nodeAddr)
+	if err != nil {
+		return err
+	}
+	err = cli.Do(context.TODO(), "CLUSTERX", "setnodeid", nodeID).Err()
+	if err != nil {
+		return err
+	}
+	err = cli.Do(context.TODO(), "CLUSTERX", "setnodes", clusterStr, ver).Err()
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
### Describe
Custer nodes probe, compare node and controller cluster version, if node less than controller, will update cluster info to nodes. It is conventional health detection method for distributed system. And opt some cli commands by  urfave/cli Args() changes command line filed variable.

### TODO
If node probe error(node fail or net connection) will start node failover

### Changes
* add healthprobe.go manager ns/cluster probe start and stop.
* probe.go handler a clustrer probe.

### Opts
* do, pdo, cd, mkns cli commands  use urfave/cli Args() replace args fields , more elegant.