### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ $ ./_build/kvrocks-controller-server -c config/config.yaml
 
 ```shell
 # create namespace
-$ curl -XPOST -d '{"namespace":"test-ns"}'  -i "http://127.0.0.1:9379/api/v1/namespaces"
+$ curl -XPOST -d '{"namespace":"test-ns"}'  -i "http://127.0.0.1:9380/api/v1/namespaces"
 # create cluster
-$ curl -XPOST -d '{"name":"test-cluster", "nodes":["127.0.0.1:6666","127.0.0.1:6667"], "replicas":2}'  -i "http://127.0.0.1:9379/api/v1/namespaces/test-ns/clusters"
+$ curl -XPOST -d '{"name":"test-cluster", "nodes":["127.0.0.1:6666","127.0.0.1:6667"], "replicas":2}'  -i "http://127.0.0.1:9380/api/v1/namespaces/test-ns/clusters"
 ```
 


### PR DESCRIPTION
The port requested in the Readme is 9379, but the default port in the [config.yaml](https://github.com/KvrocksLabs/kvrocks_controller/blob/unstable/config/config.yaml#L1) is 9380