### PR TITLE
Add builder image option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ coverage.*
 cmd/cli/cli
 cmd/server/kvrocks_controller
 .kc_cli_history
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,15 @@ CCCOLOR="\033[37;1m"
 MAKECOLOR="\033[32;1m"
 ENDCOLOR="\033[0m"
 
+BUILDER_IMAGE="none"
+
 all: $(PROGRAM)
 
 .PHONY: all
 
 
 $(PROGRAM):
-	@bash build.sh
+	@bash build.sh $(BUILDER_IMAGE)
 	@echo ""
 	@printf $(MAKECOLOR)"Hint: It's a good idea to run 'make test' ;)"$(ENDCOLOR)
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Controller for the [Kvrocks](https://github.com/apache/incubator-kvrocks#---) cl
 $ git clone https://github.com/KvrocksLabs/kvrocks_controller
 $ cd kvrocks_controller
 $ make # You can find the binary file in the `_build` dir if all goes good
-# If you do not have a suitable Golang compilation environment locally, you can also use 'make BUILDER_IMAGE=golang:version' to choose a Golang image for compilation.
+# ---
+# If you do not have a suitable Golang compilation environment locally, you can also use 'make BUILDER_IMAGE=<golang:version>' to choose a Golang image for compilation.
 # $make BUILDER_IMAGE=golang:1.20.3
 ```
 
@@ -31,7 +32,7 @@ $ make # You can find the binary file in the `_build` dir if all goes good
 # Use docker-compose to setup the etcd
 $ make setup
 # Run the controller server
-$ ./_build/kvrocks-controller-server -c config/config.yaml
+$ ./_build/kvctl-server -c config/config.yaml
 ```
 ![image](docs/images/server.gif)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Controller for the [Kvrocks](https://github.com/apache/incubator-kvrocks#---) cl
 $ git clone https://github.com/KvrocksLabs/kvrocks_controller
 $ cd kvrocks_controller
 $ make # You can find the binary file in the `_build` dir if all goes good
+# If you do not have a suitable Golang compilation environment locally, you can also use 'make BUILDER_IMAGE=golang:version' to choose a Golang image for compilation.
+# $make BUILDER_IMAGE=golang:1.20.3
 ```
 
 ### 1. Run the controller server 


### PR DESCRIPTION
Also setting CGO_ENABLED=0, which results in the compiled executable having no dynamic linking.
```sh
ldd kvctl-server 
        not a dynamic executable
```