### PR TITLE
fix: support dynamic server addr

### DIFF
--- a/server/config_test.go
+++ b/server/config_test.go
@@ -47,4 +47,8 @@ func TestConfig(t *testing.T) {
 	os.Setenv("KVROCKS_CONTROLLER_HTTP_PORT", "8080")
 	cfg.init()
 	assert.Equal(t, "1.2.3.4:8080", cfg.Addr)
+
+	// unset env, avoid environmental pollution
+	os.Setenv("KVROCKS_CONTROLLER_HTTP_HOST", "")
+	os.Setenv("KVROCKS_CONTROLLER_HTTP_PORT", "")
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig(t *testing.T) {
+	cfg := Config{}
+
+	cfg.Addr = ""
+	cfg.init()
+	t.Log(cfg.Addr) // 172.16.40.81:9379
+
+	cfg.Addr = ":8080"
+	cfg.init()
+	t.Log(cfg.Addr) // 172.16.40.81:8080
+
+	addr := "1.1.1.1:8080"
+	cfg.Addr = addr
+	cfg.init()
+	assert.Equal(t, addr, cfg.Addr)
+
+	os.Setenv("KVROCKS_CONTROLLER_HTTP_HOST", "1.2.3.4")
+	os.Setenv("KVROCKS_CONTROLLER_HTTP_PORT", "8080")
+	cfg.init()
+	assert.Equal(t, "1.2.3.4:8080", cfg.Addr)
+}


### PR DESCRIPTION
### change

When deploying multiple instances, we usually use the same configuration file, but the IP address of each instance is different, so we need to get local addr dynamically.

in addition, when using k8s to deploy `kvrocks-controller`, we can directly inject pod information into the environment variables of the container.

https://kubernetes.io/zh-cn/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: xxx
spec:
  containers:
    - name: kvrocks-controller
      image: kvrocks-controller
      ...
      env:
        - name: KVROCKS_CONTROLLER_HTTP_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
         - name: KVROCKS_CONTROLLER_HTTP_PORT
           value: 8080
  restartPolicy: Never
```

<img width="1414" alt="image" src="https://github.com/RocksLabs/kvrocks_controller/assets/3785409/057fb3f7-b9cc-442e-bed3-595d3d885324">

