### PR TITLE
fix: remove cluster safely on failover

### DIFF
--- a/controller/failover/failover.go
+++ b/controller/failover/failover.go
@@ -105,6 +105,7 @@ func (f *FailOver) gcClusters() {
 			f.rw.Lock()
 			for name, cluster := range f.clusters {
 				if cluster.IsEmpty() {
+					cluster.Close()
 					delete(f.clusters, name)
 				}
 			}


### PR DESCRIPTION
### change

remove cluster safely on failover, avoid goroutine leak.