### PR TITLE
fix using create cluster will cause runtime error 

### DIFF
--- a/cmd/client/executor.go
+++ b/cmd/client/executor.go
@@ -250,6 +250,9 @@ func (e *Executor) create(words []string) (err error) {
 		err = e.request.CreateNamespace(namespace)
 	case promptStateNamespace:
 		ns := e.promptCtx.namespace
+		if len(words) < 3 {
+			return ErrWrongArguments
+		}
 		if words[1] != typeCluster {
 			return fmt.Errorf("cannot create '%s' in namespace state", words[2])
 		}

--- a/cmd/client/executor_test.go
+++ b/cmd/client/executor_test.go
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_create(t *testing.T) {
+	request := NewRequest(config.Endpoint)
+	promptCtx := NewPromptContext()
+	executor := NewExecutor(promptCtx, request)
+
+	executor.promptCtx.state = promptStateNamespace
+	words := [...]string{"create", "cluster"}
+	require.EqualError(t, executor.create(words[:]), ErrWrongArguments.Error())
+}


### PR DESCRIPTION
fix when input error, it will cause runtime error and exit client
```
test-ns>> create x
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
main.(*Executor).create(0xc0000cb0d8?, {0xc0003463c0?, 0xc000360690?, 0x0?})
	/home/jack/repo/kvrocks_controller/cmd/client/executor.go:254 +0x266
main.(*Executor).Execute(0x4f06aa?, {0xc0000cb0d8, 0x8})
	/home/jack/repo/kvrocks_controller/cmd/client/executor.go:64 +0x116
main.main.func1({0xc0000cb0d8?, 0x0?})
	/home/jack/repo/kvrocks_controller/cmd/client/client.go:54 +0x2b
github.com/c-bata/go-prompt.(*Prompt).Run(0xc00013a3f0)
	/home/jack/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:84 +0x745
main.main()
	/home/jack/repo/kvrocks_controller/cmd/client/client.go:66 +0x352
```