### PR TITLE
 Add import cluster API for adding existing clusters

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -168,6 +168,50 @@ GET /api/v1/namespaces/{namespace}/clusters
 }
 ```
 
+### Import Cluster
+
+This API is used to import the cluster from the existing Kvrocks cluster's nodes.
+
+```shell
+GET /api/v1/namespaces/{namespace}/clusters/{cluster}/import
+```
+
+#### Request Body
+
+```json
+{
+  "nodes":["127.0.0.1:6666"],
+  "password":""
+}
+```
+
+#### Response JSON Body
+
+* 201
+```json
+{
+  "data": "created"
+}
+```
+
+* 409
+```json
+{
+  "error": {
+    "message": "the entry already existed"
+  }
+}
+```
+
+* 5XX
+```json
+{
+  "error": {
+    "message": "DETAIL ERROR STRING"
+  }
+}
+```
+
 ### Get Cluster
 
 ```shell
@@ -613,7 +657,7 @@ In this case, it only migrates slot distributions between shards and the data wi
 So you MUST ensure that the data is already migrated before you call this API.
 
 ```shell
-POST /api/v1/namespaces/{namespace}/clusters/{cluster}/shards/migration/slot_data
+POST /api/v1/namespaces/{namespace}/clusters/{cluster}/shards/migration/slot_only
 ```
 #### Request Body
 

--- a/server/route.go
+++ b/server/route.go
@@ -67,6 +67,7 @@ func (srv *Server) initHandlers() {
 			clusters.GET("", cluster.List)
 			clusters.GET("/:cluster", cluster.Get)
 			clusters.POST("", cluster.Create)
+			clusters.POST("/:cluster/import", cluster.Import)
 			clusters.DELETE("/:cluster", cluster.Remove)
 			clusters.GET("/:cluster/failover/:type", cluster.GetFailOverTasks)
 		}


### PR DESCRIPTION
This API is used to help users import their existing clusters into the Kvrocks controller, the flow is like the create API but cluster node information comes from existing nodes. For now, we allow passing the existing node list but only parses it from the first one, maybe we can retry other nodes if the first one is not broken.