### PR TITLE
Remove the migrate and failover history from the storage

### DIFF
--- a/controller/failover/cluster.go
+++ b/controller/failover/cluster.go
@@ -207,5 +207,4 @@ func (c *Cluster) promoteMaster(ctx context.Context, task *storage.FailoverTask)
 	}
 
 	task.FinishTime = time.Now().Unix()
-	_ = c.storage.AddFailOverHistory(ctx, task)
 }

--- a/controller/failover/failover.go
+++ b/controller/failover/failover.go
@@ -140,8 +140,6 @@ func (f *FailOver) GetTasks(ctx context.Context, ns, cluster string, queryType s
 			return nil, nil
 		}
 		return f.clusters[clusterKey].GetTasks()
-	case "history":
-		return f.storage.GetFailOverHistory(ctx, ns, cluster)
 	default:
 		return nil, errors.New("unknown query type")
 	}

--- a/controller/migrate/migrator.go
+++ b/controller/migrate/migrator.go
@@ -229,7 +229,6 @@ func (m *Migrator) abortMigratingTask(ctx context.Context, task *storage.Migrati
 	task.ErrorDetail = err.Error()
 	task.FinishTime = time.Now().Unix()
 	_ = m.removeMigratingTask(ctx, task)
-	_ = m.storage.AddMigrateHistory(ctx, task)
 	logger.Get().With(
 		zap.Error(err),
 		zap.Any("task", task),
@@ -240,7 +239,6 @@ func (m *Migrator) finishMigratingTask(ctx context.Context, task *storage.Migrat
 	task.Status = TaskStatusSuccess
 	task.FinishTime = time.Now().Unix()
 	_ = m.removeMigratingTask(ctx, task)
-	_ = m.storage.AddMigrateHistory(ctx, task)
 	logger.Get().With(
 		zap.Any("task", task),
 	).Info("Success to migrate the slot")

--- a/storage/failover.go
+++ b/storage/failover.go
@@ -66,29 +66,3 @@ func (s *Storage) GetFailOverTask(ctx context.Context, ns, cluster string) (*Fai
 	}
 	return &task, nil
 }
-
-func (s *Storage) AddFailOverHistory(ctx context.Context, task *FailoverTask) error {
-	taskKey := buildFailOverHistoryKey(task.Namespace, task.Cluster, task.Node.ID, task.QueuedTime)
-	taskData, err := json.Marshal(task)
-	if err != nil {
-		return err
-	}
-	return s.persist.Set(ctx, taskKey, taskData)
-}
-
-func (s *Storage) GetFailOverHistory(ctx context.Context, ns, cluster string) ([]*FailoverTask, error) {
-	prefixKey := buildFailOverHistoryPrefix(ns, cluster)
-	entries, err := s.persist.List(ctx, prefixKey)
-	if err != nil {
-		return nil, err
-	}
-	tasks := make([]*FailoverTask, 0)
-	for _, entry := range entries {
-		var task FailoverTask
-		if err = json.Unmarshal(entry.Value, &task); err != nil {
-			return nil, err
-		}
-		tasks = append(tasks, &task)
-	}
-	return tasks, nil
-}

--- a/storage/helper.go
+++ b/storage/helper.go
@@ -41,22 +41,6 @@ func buildMigratingKeyPrefix(ns, cluster string) string {
 	return fmt.Sprintf("%s/%s/migrate/doing", buildClusterPrefix(ns), cluster)
 }
 
-func buildMigrateHistoryKey(ns, cluster, taskID string) string {
-	return fmt.Sprintf("%s/%s/migrate/history/%s", buildClusterPrefix(ns), cluster, taskID)
-}
-
-func buildMigrateHistoryPrefix(ns, cluster string) string {
-	return fmt.Sprintf("%s/%s/migrate/history/", buildClusterPrefix(ns), cluster)
-}
-
 func buildFailOverKey(ns, cluster string) string {
 	return fmt.Sprintf("%s/%s/failover/queue", buildClusterPrefix(ns), cluster)
-}
-
-func buildFailOverHistoryKey(ns, cluster, node string, ts int64) string {
-	return fmt.Sprintf("%s/%s/failover/history/%d/%s", buildClusterPrefix(ns), cluster, ts, node)
-}
-
-func buildFailOverHistoryPrefix(ns, cluster string) string {
-	return fmt.Sprintf("%s/%s/failover/history/", buildClusterPrefix(ns), cluster)
 }

--- a/storage/migrate.go
+++ b/storage/migrate.go
@@ -77,38 +77,3 @@ func (s *Storage) RemoveMigratingTask(ctx context.Context, ns, cluster string) e
 	taskKey := buildMigratingKeyPrefix(ns, cluster)
 	return s.persist.Delete(ctx, taskKey)
 }
-
-func (s *Storage) AddMigrateHistory(ctx context.Context, task *MigrationTask) error {
-	taskKey := buildMigrateHistoryKey(task.Namespace, task.Cluster, task.TaskID)
-	taskData, err := json.Marshal(task)
-	if err != nil {
-		return err
-	}
-	return s.persist.Set(ctx, taskKey, taskData)
-}
-
-func (s *Storage) GetMigrateHistory(ctx context.Context, ns, cluster string) ([]*MigrationTask, error) {
-	prefixKey := buildMigrateHistoryPrefix(ns, cluster)
-	entries, err := s.persist.List(ctx, prefixKey)
-	if err != nil {
-		return nil, err
-	}
-	var tasks []*MigrationTask
-	for _, entry := range entries {
-		var task MigrationTask
-		if err = json.Unmarshal(entry.Value, &task); err != nil {
-			return nil, err
-		}
-		tasks = append(tasks, &task)
-	}
-	return tasks, nil
-}
-
-func (s *Storage) IsMigrateHistoryExists(ctx context.Context, task *MigrationTask) (bool, error) {
-	taskKey := buildMigrateHistoryKey(task.Namespace, task.Cluster, task.TaskID)
-	value, err := s.persist.Get(ctx, taskKey)
-	if err != nil {
-		return false, err
-	}
-	return len(value) != 0, nil
-}


### PR DESCRIPTION
Currently, all failover/migrate operations will be recorded in storage which may slowdown the service if users frequently migrate or failover. So it'd be better to remove history records before thinking through how do we use and retain them.