### PR TITLE
Modify the CI running conditions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,7 @@
 #
 name: CI Actions  # don't edit while the badge was depend on this
 
-on:
-  push:
-    branches:
-      - unstable
-  pull_request:
-    branches:
-      - unstable
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed that CI doesn't run unless on unstable branches, which makes it difficult for contributors to run CI on their own forked branches. 

Therefore, I have now modified the CI running conditions (make it same as apache/kvrocks). This will allow contributors to find their errors in CI easily.