### PR TITLE
Add the random string when generating the session id

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/apache/kvrocks-controller/config"
@@ -86,6 +87,10 @@ func main() {
 	if err := cfg.Validate(); err != nil {
 		logger.Get().With(zap.Error(err)).Error("Failed to validate the config file")
 		return
+	}
+	hostPort := strings.Split(cfg.Addr, ":")
+	if hostPort[0] == "0.0.0.0" || hostPort[0] == "127.0.0.1" {
+		logger.Get().Warn("Leader forward may not work if the host is " + hostPort[0])
 	}
 	srv, err := server.NewServer(cfg)
 	if err != nil {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -69,7 +69,8 @@ func RedirectIfNotLeader(c *gin.Context) {
 	if !storage.IsLeader() {
 		if !c.GetBool(consts.HeaderIsRedirect) {
 			c.Set(consts.HeaderIsRedirect, true)
-			c.Redirect(http.StatusTemporaryRedirect, "http://"+storage.Leader()+c.Request.RequestURI)
+			peerAddr := extractAddrFromSessionID(storage.Leader())
+			c.Redirect(http.StatusTemporaryRedirect, "http://"+peerAddr+c.Request.RequestURI)
 		} else {
 			responseBadRequest(c, errors.New("too many redirects"))
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -50,18 +50,19 @@ type Server struct {
 func NewServer(cfg *config.Config) (*Server, error) {
 	var persist persistence.Persistence
 	var err error
+
+	sessionID := generateSessionID(cfg.Addr)
 	switch {
 	case strings.EqualFold(cfg.StorageType, "etcd"):
 		logger.Get().Info("Use Etcd as storage")
-		persist, err = etcd.New(cfg.Addr, cfg.Etcd)
+		persist, err = etcd.New(sessionID, cfg.Etcd)
 	case strings.EqualFold(cfg.StorageType, "zookeeper"):
 		logger.Get().Info("Use Zookeeper as storage")
-		persist, err = zookeeper.New(cfg.Addr, cfg.Zookeeper)
+		persist, err = zookeeper.New(sessionID, cfg.Zookeeper)
 	default:
 		logger.Get().Info("Use Etcd as default storage")
-		persist, err = etcd.New(cfg.Addr, cfg.Etcd)
+		persist, err = etcd.New(sessionID, cfg.Etcd)
 	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -21,9 +21,12 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/apache/kvrocks-controller/metadata"
+	"github.com/apache/kvrocks-controller/util"
 
 	"github.com/gin-gonic/gin"
 )
@@ -67,4 +70,21 @@ func responseError(c *gin.Context, err error) {
 	c.JSON(code, Response{
 		Error: &Error{Message: err.Error()},
 	})
+}
+
+// generateSessionID encodes the addr to a session ID,
+// which is used to identify the session. And then can be used to
+// parse the leader listening address back.
+func generateSessionID(addr string) string {
+	return fmt.Sprintf("%s/%s", util.RandString(8), addr)
+}
+
+// extractAddrFromSessionID decodes the session ID to the addr.
+func extractAddrFromSessionID(sessionID string) string {
+	parts := strings.Split(sessionID, "/")
+	if len(parts) != 2 {
+		// for the old session ID format, we use the addr as the session ID
+		return sessionID
+	}
+	return parts[1]
 }

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package server
 
 import (

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGenerateSessionID(t *testing.T) {
+	testAddr := "127.0.0.1:1234"
+	sessionID := generateSessionID(testAddr)
+	decodedAddr := extractAddrFromSessionID(sessionID)
+	require.Equal(t, testAddr, decodedAddr)
+
+	// old format
+	require.Equal(t, testAddr, extractAddrFromSessionID(testAddr))
+}

--- a/storage/persistence/persistence.go
+++ b/storage/persistence/persistence.go
@@ -28,17 +28,27 @@ type Entry struct {
 	Value []byte
 }
 
-type Persistence interface {
+// Elector is a leader election interface,
+// it is used to elect a leader from a group of electors.
+type Elector interface {
 	ID() string
 	Leader() string
 	LeaderChange() <-chan bool
-	IsReady(ctx context.Context) bool
+}
 
+// KVStore is a key-value store interface
+type KVStore interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Exists(ctx context.Context, key string) (bool, error)
 	Set(ctx context.Context, key string, value []byte) error
 	Delete(ctx context.Context, key string) error
 	List(ctx context.Context, prefix string) ([]Entry, error)
+}
 
+type Persistence interface {
+	Elector
+	KVStore
+
+	IsReady(ctx context.Context) bool
 	Close() error
 }


### PR DESCRIPTION
This closes #157 

Currently, we're using the listening address as the session id,
and it will cause conflicts if they're using 0.0.0.0 as its listening address.