### PR TITLE
Improve the operation of slot in SlotRanges

### DIFF
--- a/controller/cluster.go
+++ b/controller/cluster.go
@@ -298,11 +298,9 @@ func (c *ClusterChecker) tryUpdateMigrationStatus(ctx context.Context, cluster *
 				log.Error("Failed to set the slot", zap.Error(err))
 				return
 			}
-			cluster.Shards[i].SlotRanges = store.RemoveSlotRanges(cluster.Shards[i].SlotRanges,
-				[]store.SlotRange{{Start: shard.MigratingSlot, Stop: shard.MigratingSlot}})
-			cluster.Shards[shard.TargetShardIndex].SlotRanges = store.MergeSlotRanges(
-				cluster.Shards[shard.TargetShardIndex].SlotRanges,
-				[]store.SlotRange{{Start: shard.MigratingSlot, Stop: shard.MigratingSlot}})
+			cluster.Shards[i].SlotRanges = store.RemoveSlotFromSlotRanges(cluster.Shards[i].SlotRanges, shard.MigratingSlot)
+			cluster.Shards[shard.TargetShardIndex].SlotRanges = store.AddSlotToSlotRanges(
+				cluster.Shards[shard.TargetShardIndex].SlotRanges, shard.MigratingSlot)
 			cluster.Shards[i].ClearMigrateState()
 			if err := c.clusterStore.SetCluster(ctx, c.namespace, cluster); err != nil {
 				log.Error("Failed to update the cluster", zap.Error(err))

--- a/store/cluster.go
+++ b/store/cluster.go
@@ -53,7 +53,7 @@ func NewCluster(name string, nodes []string, replicas int) (*Cluster, error) {
 	}
 	shardCount := len(nodes) / replicas
 	shards := make([]*Shard, 0)
-	slotRanges := SpiltSlotRange(shardCount)
+	slotRanges := CalculateSlotRanges(shardCount)
 	for i := 0; i < shardCount; i++ {
 		shard := NewShard()
 		shard.Nodes = make([]Node, 0)
@@ -186,9 +186,8 @@ func (cluster *Cluster) MigrateSlot(ctx context.Context, slot int, targetShardId
 		return consts.ErrShardIsSame
 	}
 	if slotOnly {
-		migrateSlot := SlotRange{Start: slot, Stop: slot}
-		cluster.Shards[sourceShardIdx].SlotRanges = RemoveSlotRanges(cluster.Shards[sourceShardIdx].SlotRanges, []SlotRange{migrateSlot})
-		cluster.Shards[targetShardIdx].SlotRanges = MergeSlotRanges(cluster.Shards[targetShardIdx].SlotRanges, []SlotRange{migrateSlot})
+		cluster.Shards[sourceShardIdx].SlotRanges = RemoveSlotFromSlotRanges(cluster.Shards[sourceShardIdx].SlotRanges, slot)
+		cluster.Shards[targetShardIdx].SlotRanges = AddSlotToSlotRanges(cluster.Shards[targetShardIdx].SlotRanges, slot)
 		return nil
 	}
 

--- a/store/slot_test.go
+++ b/store/slot_test.go
@@ -57,113 +57,79 @@ func TestSlotRange_Parse(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestSlotRange_MergeSlotRanges(t *testing.T) {
-	range1 := SlotRange{
-		Start: 0,
-		Stop:  8191,
+func TestAddSlotToSlotRanges(t *testing.T) {
+	slotRanges := SlotRanges{
+		{Start: 1, Stop: 20},
+		{Start: 101, Stop: 199},
+		{Start: 201, Stop: 300},
 	}
-	range2 := SlotRange{
-		Start: 8192,
-		Stop:  16383,
-	}
-	newSlot := MergeSlotRanges([]SlotRange{range1}, []SlotRange{range2})
-	assert.Equal(t, 1, len(newSlot))
-	assert.Equal(t, 0, newSlot[0].Start)
-	assert.Equal(t, 16383, newSlot[0].Stop)
+	slotRanges = AddSlotToSlotRanges(slotRanges, 0)
+	require.Equal(t, 3, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 0, Stop: 20}, slotRanges[0])
 
-	range3 := SlotRange{
-		Start: 0,
-		Stop:  8199,
-	}
-	range4 := SlotRange{
-		Start: 8192,
-		Stop:  16383,
-	}
-	newSlot = MergeSlotRanges([]SlotRange{range3}, []SlotRange{range4})
-	assert.Equal(t, 1, len(newSlot))
-	assert.Equal(t, 0, newSlot[0].Start)
-	assert.Equal(t, 16383, newSlot[0].Stop)
+	slotRanges = AddSlotToSlotRanges(slotRanges, 21)
+	require.Equal(t, 3, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 0, Stop: 21}, slotRanges[0])
+
+	slotRanges = AddSlotToSlotRanges(slotRanges, 50)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 50, Stop: 50}, slotRanges[1])
+
+	slotRanges = AddSlotToSlotRanges(slotRanges, 200)
+	require.Equal(t, 3, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 101, Stop: 300}, slotRanges[2])
+
+	slotRanges = AddSlotToSlotRanges(slotRanges, 400)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 400, Stop: 400}, slotRanges[3])
 }
 
-func TestSlotRange_RemoveSlotRanges(t *testing.T) {
-	range1 := SlotRange{
-		Start: 0,
-		Stop:  8191,
+func TestRemoveSlotRanges(t *testing.T) {
+	slotRanges := SlotRanges{
+		{Start: 1, Stop: 20},
+		{Start: 101, Stop: 199},
+		{Start: 201, Stop: 300},
 	}
-	range2 := SlotRange{
-		Start: 0,
-		Stop:  0,
-	}
-	range3 := SlotRange{
-		Start: 8191,
-		Stop:  8191,
-	}
-	newSlot := RemoveSlotRanges([]SlotRange{range1}, []SlotRange{range2})
-	assert.Equal(t, 1, newSlot[0].Start)
-	assert.Equal(t, 8191, newSlot[0].Stop)
-	newSlot = RemoveSlotRanges([]SlotRange{range1}, []SlotRange{range3})
-	assert.Equal(t, 0, newSlot[0].Start)
-	assert.Equal(t, 8190, newSlot[0].Stop)
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 0)
+	require.Equal(t, 3, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 1, Stop: 20}, slotRanges[0])
 
-	range1 = SlotRange{
-		Start: 0,
-		Stop:  8191,
-	}
-	range2 = SlotRange{
-		Start: 8192,
-		Stop:  16383,
-	}
-	range3 = SlotRange{
-		Start: 0,
-		Stop:  8192,
-	}
-	newSlot = RemoveSlotRanges([]SlotRange{range1, range2}, []SlotRange{range3})
-	assert.Equal(t, 8193, newSlot[0].Start)
-	assert.Equal(t, 16383, newSlot[0].Stop)
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 21)
+	require.Equal(t, 3, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 1, Stop: 20}, slotRanges[0])
 
-	range1 = SlotRange{
-		Start: 0,
-		Stop:  8191,
-	}
-	range2 = SlotRange{
-		Start: 8192,
-		Stop:  16383,
-	}
-	range3 = SlotRange{
-		Start: 1,
-		Stop:  8192,
-	}
-	newSlot = RemoveSlotRanges([]SlotRange{range1, range2}, []SlotRange{range3})
-	assert.Equal(t, 0, newSlot[0].Start)
-	assert.Equal(t, 0, newSlot[0].Stop)
-	assert.Equal(t, 8193, newSlot[1].Start)
-	assert.Equal(t, 16383, newSlot[1].Stop)
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 20)
+	require.Equal(t, 3, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 1, Stop: 19}, slotRanges[0])
 
-	range1 = SlotRange{
-		Start: 0,
-		Stop:  8191,
-	}
-	range2 = SlotRange{
-		Start: 8192,
-		Stop:  16383,
-	}
-	range3 = SlotRange{
-		Start: 1,
-		Stop:  8192,
-	}
-	range4 := SlotRange{
-		Start: 8194,
-		Stop:  16383,
-	}
-	newSlot = RemoveSlotRanges([]SlotRange{range1, range2}, []SlotRange{range3, range4})
-	assert.Equal(t, 0, newSlot[0].Start)
-	assert.Equal(t, 0, newSlot[0].Stop)
-	assert.Equal(t, 8193, newSlot[1].Start)
-	assert.Equal(t, 8193, newSlot[1].Stop)
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 150)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 101, Stop: 149}, slotRanges[1])
+
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 101)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 102, Stop: 149}, slotRanges[1])
+
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 199)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 151, Stop: 198}, slotRanges[2])
+
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 300)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 201, Stop: 299}, slotRanges[3])
+
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 298)
+	require.Equal(t, 5, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 201, Stop: 297}, slotRanges[3])
+	require.EqualValues(t, SlotRange{Start: 299, Stop: 299}, slotRanges[4])
+
+	slotRanges = RemoveSlotFromSlotRanges(slotRanges, 299)
+	require.Equal(t, 4, len(slotRanges))
+	require.EqualValues(t, SlotRange{Start: 201, Stop: 297}, slotRanges[3])
 }
 
-func TestSlotRange_SpiltSlotRange(t *testing.T) {
-	slots := SpiltSlotRange(5)
+func TestCalculateSlotRanges(t *testing.T) {
+	slots := CalculateSlotRanges(5)
 	assert.Equal(t, 0, slots[0].Start)
 	assert.Equal(t, 3275, slots[0].Stop)
 	assert.Equal(t, 13104, slots[4].Start)


### PR DESCRIPTION
Currently, the continuous slot ranges won't be merged
while the new slot is added which is expected in Redis behavior.

For example, we now have below slot ranges in one shard: [1,100], [102, 200], [202, 300]
and the slot `101` was added to this shard, we would like to become: [1, 200], [202, 300]
instead of [1, 101], [102, 200], [202, 300].