### PR TITLE
Add the random string when generating the session id

### DIFF
--- a/server/helper/helper.go
+++ b/server/helper/helper.go
@@ -17,15 +17,19 @@
  * under the License.
  *
  */
+
 package helper
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
-
-	"github.com/apache/kvrocks-controller/consts"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/apache/kvrocks-controller/consts"
+	"github.com/apache/kvrocks-controller/util"
 )
 
 type Error struct {
@@ -76,4 +80,21 @@ func ResponseError(c *gin.Context, err error) {
 		Error: &Error{Message: err.Error()},
 	})
 	c.Abort()
+}
+
+// generateSessionID encodes the addr to a session ID,
+// which is used to identify the session. And then can be used to
+// parse the leader listening address back.
+func GenerateSessionID(addr string) string {
+	return fmt.Sprintf("%s/%s", util.RandString(8), addr)
+}
+
+// extractAddrFromSessionID decodes the session ID to the addr.
+func ExtractAddrFromSessionID(sessionID string) string {
+	parts := strings.Split(sessionID, "/")
+	if len(parts) != 2 {
+		// for the old session ID format, we use the addr as the session ID
+		return sessionID
+	}
+	return parts[1]
 }

--- a/server/helper/helper_test.go
+++ b/server/helper/helper_test.go
@@ -17,22 +17,21 @@
  * under the License.
  *
  */
-package config
+
+package helper
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultControllerConfigSet(t *testing.T) {
-	cfg := Default()
-	expectedControllerConfig := &ControllerConfig{
-		FailOver: &FailOverConfig{
-			PingIntervalSeconds: 3,
-			MaxPingCount:        5,
-		},
-	}
+func TestGenerateSessionID(t *testing.T) {
+	testAddr := "127.0.0.1:1234"
+	sessionID := GenerateSessionID(testAddr)
+	decodedAddr := ExtractAddrFromSessionID(sessionID)
+	require.Equal(t, testAddr, decodedAddr)
 
-	assert.Equal(t, expectedControllerConfig, cfg.Controller)
+	// old format
+	require.Equal(t, testAddr, ExtractAddrFromSessionID(testAddr))
 }

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -17,6 +17,7 @@
  * under the License.
  *
  */
+
 package middleware
 
 import (
@@ -25,14 +26,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/apache/kvrocks-controller/server/helper"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/apache/kvrocks-controller/consts"
 	"github.com/apache/kvrocks-controller/metrics"
+	"github.com/apache/kvrocks-controller/server/helper"
 	"github.com/apache/kvrocks-controller/store"
-
-	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func CollectMetrics(c *gin.Context) {
@@ -69,6 +69,8 @@ func RedirectIfNotLeader(c *gin.Context) {
 	if !storage.IsLeader() {
 		if !c.GetBool(consts.HeaderIsRedirect) {
 			c.Set(consts.HeaderIsRedirect, true)
+			peerAddr := helper.ExtractAddrFromSessionID(storage.Leader())
+			c.Redirect(http.StatusTemporaryRedirect, "http://"+peerAddr+c.Request.RequestURI)
 			c.Redirect(http.StatusTemporaryRedirect, "http://"+storage.Leader()+c.Request.RequestURI)
 		} else {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no leader now, please retry later"})

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@
  * under the License.
  *
  */
+
 package server
 
 import (
@@ -32,6 +33,7 @@ import (
 	"github.com/apache/kvrocks-controller/config"
 	"github.com/apache/kvrocks-controller/controller"
 	"github.com/apache/kvrocks-controller/logger"
+	"github.com/apache/kvrocks-controller/server/helper"
 	"github.com/apache/kvrocks-controller/store"
 	"github.com/apache/kvrocks-controller/store/engine"
 	"github.com/apache/kvrocks-controller/store/engine/etcd"
@@ -49,16 +51,18 @@ type Server struct {
 func NewServer(cfg *config.Config) (*Server, error) {
 	var persist engine.Engine
 	var err error
+
+	sessionID := helper.GenerateSessionID(cfg.Addr)
 	switch {
 	case strings.EqualFold(cfg.StorageType, "etcd"):
 		logger.Get().Info("Use Etcd as store")
-		persist, err = etcd.New(cfg.Addr, cfg.Etcd)
+		persist, err = etcd.New(sessionID, cfg.Etcd)
 	case strings.EqualFold(cfg.StorageType, "zookeeper"):
 		logger.Get().Info("Use Zookeeper as store")
-		persist, err = zookeeper.New(cfg.Addr, cfg.Zookeeper)
+		persist, err = zookeeper.New(sessionID, cfg.Zookeeper)
 	default:
 		logger.Get().Info("Use Etcd as default store")
-		persist, err = etcd.New(cfg.Addr, cfg.Etcd)
+		persist, err = etcd.New(sessionID, cfg.Etcd)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This closes #157 

Currently, we're using the listening address as the session ID,
and it will cause conflicts if they use 0.0.0.0 as its listening address.