### PR TITLE
Fix possible slot range loss in the importing API

### DIFF
--- a/store/cluster_node_test.go
+++ b/store/cluster_node_test.go
@@ -45,8 +45,12 @@ func TestClusterNode(t *testing.T) {
 
 		require.NoError(t, redisCli.Do(ctx, "CLUSTER", "RESET").Err())
 		// set the cluster topology
-		cluster := &Cluster{Shards: Shards{
-			{Nodes: []Node{node}, SlotRanges: []SlotRange{{Start: 0, Stop: 16383}}},
+		cluster := &Cluster{Shards: Shards{{
+			Nodes: []Node{node}, SlotRanges: []SlotRange{
+				{Start: 0, Stop: 100},
+				{Start: 102, Stop: 300},
+				{Start: 302, Stop: 16383},
+			}},
 		}}
 		cluster.Version.Store(1)
 		require.NoError(t, node.SyncClusterInfo(ctx, cluster))
@@ -70,6 +74,11 @@ func TestClusterNode(t *testing.T) {
 		require.EqualValues(t, 1, clusterNodes.Version.Load())
 		require.Len(t, clusterNodes.Shards, 1)
 		require.Len(t, clusterNodes.Shards[0].Nodes, 1)
+		require.EqualValues(t, []SlotRange{
+			{Start: 0, Stop: 100},
+			{Start: 102, Stop: 300},
+			{Start: 302, Stop: 16383},
+		}, clusterNodes.Shards[0].SlotRanges)
 		require.EqualValues(t, defaultNodeAddr, clusterNodes.Shards[0].Nodes[0].Addr())
 		require.EqualValues(t, node.ID(), clusterNodes.Shards[0].Nodes[0].ID())
 	})


### PR DESCRIPTION
This closes #184

Currently, the controller only parsed the first slot range
when importing the cluster. So it might be lost remain slot ranges
if the shard has more than one slot range.