### PR TITLE
Remove unused build flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           export PATH=$PATH:$GOPATH/bin
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
           make lint
-  
+
   build-test:
     name: Build and test
     needs: [lint]
@@ -92,14 +92,4 @@ jobs:
           file: ./coverage.out
           flags: unittests
           name: codecov-umbrella
-       
-  check-docker:
-    name: Check Docker image
-    needs: [lint]
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
+

--- a/build.sh
+++ b/build.sh
@@ -75,8 +75,6 @@ fi
 GO_PROJECT=github.com/apache/kvrocks-controller
 BUILD_DIR=./_build
 VERSION=`cat VERSION.txt`
-BUILD_DATE=`date -u +'%Y-%m-%dT%H:%M:%SZ'`
-GIT_REVISION=`git rev-parse --short HEAD`
 
 SERVER_TARGET_NAME=kvctl-server
 CLIENT_TARGET_NAME=kvctl
@@ -90,13 +88,13 @@ for TARGET_NAME in "$SERVER_TARGET_NAME" "$CLIENT_TARGET_NAME"; do
 
     if [[ "$BUILDER_IMAGE" == "none" ]]; then
         GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" CGO_ENABLED=0 go build -v -ldflags \
-            "-X $GO_PROJECT/version.Version=$VERSION -X $GO_PROJECT/version.BuildDate=$BUILD_DATE -X $GO_PROJECT/version.BuildCommit=$GIT_REVISION" \
+            "-X $GO_PROJECT/version.Version=$VERSION" \
             -o ${TARGET_NAME} ${CMD_PATH}
     else
         docker run --rm --privileged -it -v $(pwd):/${TARGET_NAME} -w /${TARGET_NAME} \
             -e GOOS="$TARGET_OS" -e GOARCH="$TARGET_ARCH" -e CGO_ENABLED=0 \
             $BUILDER_IMAGE go build -v -ldflags \
-            "-X $GO_PROJECT/version.Version=$VERSION -X $GO_PROJECT/version.BuildDate=$BUILD_DATE -X $GO_PROJECT/version.BuildCommit=$GIT_REVISION" \
+            "-X $GO_PROJECT/version.Version=$VERSION" \
             -o /${TARGET_NAME}/${TARGET_NAME} ${CMD_PATH}
     fi
 


### PR DESCRIPTION
BuildDate and Commit ID aren't used now and we can remove them to allow to build from the tarball.