### PR TITLE
Replace `docker-compose` with `docker compose`

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,4 +16,4 @@
 # under the License.
 #
 
-cd docker && docker-compose -p kvrocks-controller up -d --force-recreate && cd ..
+cd docker && docker compose -p kvrocks-controller up -d --force-recreate && cd ..

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -18,4 +18,4 @@
 
 set -e
 
-cd docker && docker-compose -p kvrocks-controller down && cd ..
+cd docker && docker compose -p kvrocks-controller down && cd ..


### PR DESCRIPTION
The current GitHub Action env `ubuntu-latest` don't have the `docker-compose` command. I have replaced `docker-compose` with `docker compose`.

See https://github.com/apache/kvrocks-controller/actions/runs/10227442375/job/28298937539?pr=197#step:6:5