### PR TITLE
add api basic auth support

### DIFF
--- a/cmd/client/command/client.go
+++ b/cmd/client/command/client.go
@@ -48,11 +48,16 @@ type response struct {
 	Data  any           `json:"data"`
 }
 
-func newClient(host string) *client {
+func newClient(host, apiUser, apiPass string) *client {
 	if host == "" {
 		host = defaultHost
 	}
-	restyCli := resty.New().SetBaseURL(host + apiVersionV1)
+	var restyCli *resty.Client
+	if apiUser != "" && apiPass != "" {
+		restyCli = resty.New().SetDisableWarn(true).SetBaseURL(host+apiVersionV1).SetBasicAuth(apiUser, apiPass)
+	} else {
+		restyCli = resty.New().SetBaseURL(host + apiVersionV1)
+	}
 	return &client{
 		restyCli: restyCli,
 		host:     host,

--- a/cmd/client/command/create.go
+++ b/cmd/client/command/create.go
@@ -58,7 +58,9 @@ kvctl create node 127.0.0.1:6379 -n <namespace> -c <cluster> --shard <shard>
 	PreRunE: createPreRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		switch strings.ToLower(args[0]) {
 		case ResourceNamespace:
 			if len(args) < 2 {

--- a/cmd/client/command/delete.go
+++ b/cmd/client/command/delete.go
@@ -59,7 +59,9 @@ kvctl delete node <node_id> -n <namespace> -c <cluster> --shard <shard>
 			return fmt.Errorf("missing resource name")
 		}
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		switch resource {
 		case ResourceNamespace:
 			namespace := args[1]

--- a/cmd/client/command/failover.go
+++ b/cmd/client/command/failover.go
@@ -51,7 +51,9 @@ kvctl failover shard <shard_index> --preferred <node_id> -n <namespace> -c <clus
 			return fmt.Errorf("missing shard index, plese specify the shard index")
 		}
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		resource := args[0]
 		switch resource {
 		case "shard":

--- a/cmd/client/command/get.go
+++ b/cmd/client/command/get.go
@@ -46,7 +46,9 @@ kvctl get cluster <cluster> -n <namespace>
 	PreRunE: getPreRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		if len(args) < 2 {
 			return fmt.Errorf("missing resource name, must be one of [cluster, shard]")
 		}

--- a/cmd/client/command/import.go
+++ b/cmd/client/command/import.go
@@ -47,7 +47,9 @@ kvctl import cluster <cluster> --nodes 127.0.0.1:6379,127.0.0.1:6380
 	PreRunE: importPreRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		resource := strings.ToLower(args[0])
 		switch resource {
 		case ResourceCluster:

--- a/cmd/client/command/list.go
+++ b/cmd/client/command/list.go
@@ -48,7 +48,9 @@ kvctl list nodes -n <namespace> -c <cluster>
 	ValidArgs: []string{"namespaces", "clusters", "shards", "nodes"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		switch strings.ToLower(args[0]) {
 		case "namespaces":
 			return listNamespace(client)

--- a/cmd/client/command/migrate.go
+++ b/cmd/client/command/migrate.go
@@ -49,7 +49,9 @@ kvctl migrate slot <slot> --target <target_shard_index> -n <namespace> -c <clust
 	PreRunE: migrationPreRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
-		client := newClient(host)
+		user, _ := cmd.Flags().GetString("api-user")
+		password, _ := cmd.Flags().GetString("api-password")
+		client := newClient(host, user, password)
 		resource := strings.ToLower(args[0])
 		switch resource {
 		case "slot":

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -49,6 +49,10 @@ func main() {
 func init() {
 	rootCommand.PersistentFlags().StringP("host", "H",
 		"http://127.0.0.1:9379", "The host of the Kvrocks controller service")
+	rootCommand.PersistentFlags().StringP("api-user", "U",
+		"", "The user of the Kvrocks controller api")
+	rootCommand.PersistentFlags().StringP("api-password", "P",
+		"", "The password of the Kvrocks controller api user")
 
 	rootCommand.AddCommand(command.ListCommand)
 	rootCommand.AddCommand(command.CreateCommand)

--- a/config/config.go
+++ b/config/config.go
@@ -98,7 +98,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) IsApiAuthConfigured() bool {
-	if c.ApiAuth.User != "" && c.ApiAuth.Password != "" {
+	if c.ApiAuth.Username != "" && c.ApiAuth.Password != "" {
 		return true
 	}
 	return false

--- a/config/config.go
+++ b/config/config.go
@@ -38,8 +38,8 @@ type AdminConfig struct {
 }
 
 type ApiAuthConfig struct {
-	ApiUser     string `yaml:"apiUser"`
-	ApiPassword string `yaml:"apiPassword"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
 }
 
 type FailOverConfig struct {
@@ -60,7 +60,7 @@ type Config struct {
 	Zookeeper   *zookeeper.Config `yaml:"zookeeper"`
 	Admin       AdminConfig       `yaml:"admin"`
 	Controller  *ControllerConfig `yaml:"controller"`
-	ApiAuth     *ApiAuthConfig    `yaml:"apiAuth"`
+	ApiAuth     *ApiAuthConfig    `yaml:"api_auth"`
 }
 
 func DefaultFailOverConfig() *FailOverConfig {
@@ -95,6 +95,13 @@ func (c *Config) Validate() error {
 		logger.Get().Warn("Leader forward may not work if the host is " + hostPort[0])
 	}
 	return nil
+}
+
+func (c *Config) IsApiAuthConfigured() bool {
+	if c.ApiAuth.User != "" && c.ApiAuth.Password != "" {
+		return true
+	}
+	return false
 }
 
 func (c *Config) getAddr() string {
@@ -137,3 +144,4 @@ func getLocalIP() string {
 	}
 	return ""
 }
+

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,11 @@ type AdminConfig struct {
 	Addr string `yaml:"addr"`
 }
 
+type ApiAuthConfig struct {
+	ApiUser     string `yaml:"apiUser"`
+	ApiPassword string `yaml:"apiPassword"`
+}
+
 type FailOverConfig struct {
 	PingIntervalSeconds int   `yaml:"ping_interval_seconds"`
 	MaxPingCount        int64 `yaml:"max_ping_count"`
@@ -55,6 +60,7 @@ type Config struct {
 	Zookeeper   *zookeeper.Config `yaml:"zookeeper"`
 	Admin       AdminConfig       `yaml:"admin"`
 	Controller  *ControllerConfig `yaml:"controller"`
+	ApiAuth     *ApiAuthConfig    `yaml:"apiAuth"`
 }
 
 func DefaultFailOverConfig() *FailOverConfig {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,6 +18,9 @@
 
 addr: "127.0.0.1:9379"
 
+apiAuth:
+  apiUser: "testUser"
+  apiPassword: "testPassword"
 
 # Which store engine should be used by controller
 # options: etcd, zookeeper

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,9 +18,10 @@
 
 addr: "127.0.0.1:9379"
 
-apiAuth:
-  apiUser: "testUser"
-  apiPassword: "testPassword"
+# api basic auth
+api_auth:
+  username: "testUser"
+  password: "testPassword"
 
 # Which store engine should be used by controller
 # options: etcd, zookeeper

--- a/consts/context_key.go
+++ b/consts/context_key.go
@@ -24,6 +24,7 @@ const (
 	ContextKeyCluster      = "_context_key_cluster"
 	ContextKeyClusterShard = "_context_key_cluster_shard"
 	ContextKeyHost         = "_context_key_host"
+	ContextKeyApiAuth      = "_context_key_api_auth"
 )
 
 const (

--- a/server/route.go
+++ b/server/route.go
@@ -36,6 +36,14 @@ func (srv *Server) initHandlers() {
 		c.Set(consts.ContextKeyStore, srv.store)
 		c.Next()
 	}, middleware.RedirectIfNotLeader)
+
+	if srv.config.ApiAuth.ApiUser != "" && srv.config.ApiAuth.ApiPassword != "" {
+		engine.Use(func(c *gin.Context) {
+			c.Set(consts.ContextKeyApiAuth, srv.config.ApiAuth.ApiUser+":"+srv.config.ApiAuth.ApiPassword)
+			c.Next()
+		}, middleware.RequiredAuth)
+	}
+
 	handler := api.NewHandler(srv.store)
 
 	engine.Any("/debug/pprof/*profile", PProf)

--- a/server/route.go
+++ b/server/route.go
@@ -37,9 +37,9 @@ func (srv *Server) initHandlers() {
 		c.Next()
 	}, middleware.RedirectIfNotLeader)
 
-	if srv.config.ApiAuth.ApiUser != "" && srv.config.ApiAuth.ApiPassword != "" {
+	if srv.config.IsApiAuthConfigured() {
 		engine.Use(func(c *gin.Context) {
-			c.Set(consts.ContextKeyApiAuth, srv.config.ApiAuth.ApiUser+":"+srv.config.ApiAuth.ApiPassword)
+			c.Set(consts.ContextKeyApiAuth, srv.config.ApiAuth.Username+":"+srv.config.ApiAuth.Password)
 			c.Next()
 		}, middleware.RequiredAuth)
 	}
@@ -90,3 +90,4 @@ func (srv *Server) initHandlers() {
 		}
 	}
 }
+


### PR DESCRIPTION
Implement basic auth for api interface base on gin middleware.

Although gin has its own gin.BasicAuth() middleware, but I still implemented it by myself for future expansion.