### PR TITLE
Remove the detection of GOARCH and GOOS when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,13 @@ CCCOLOR="\033[37;1m"
 MAKECOLOR="\033[32;1m"
 ENDCOLOR="\033[0m"
 
-BUILDER_IMAGE="none"
-
 all: $(PROGRAM)
 
 .PHONY: all
 
 
 $(PROGRAM):
-	@bash scripts/build.sh $(BUILDER_IMAGE)
+	@bash scripts/build.sh
 	@echo ""
 	@printf $(MAKECOLOR)"Hint: It's a good idea to run 'make test' ;)"$(ENDCOLOR)
 	@echo ""

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,7 @@ for TARGET_NAME in "$SERVER_TARGET_NAME" "$CLIENT_TARGET_NAME"; do
         CMD_PATH="${GO_PROJECT}/cmd/client"
     fi
 
-    GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" CGO_ENABLED=0 go build -v -ldflags \
+    CGO_ENABLED=0 go build -v -ldflags \
         "-X $GO_PROJECT/version.Version=$VERSION" \
         -o ${TARGET_NAME} ${CMD_PATH}
 
@@ -41,7 +41,7 @@ for TARGET_NAME in "$SERVER_TARGET_NAME" "$CLIENT_TARGET_NAME"; do
         exit 1
     fi
 
-    echo "Build $TARGET_NAME, OS is $TARGET_OS, Arch is $TARGET_ARCH"
+    echo "Build $TARGET_NAME successfully"
 done
 
 rm -rf ${BUILD_DIR}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,60 +17,6 @@
 #
 
 set -e
-BUILDER_IMAGE=${1:-none}
-if test -z "$TARGET_OS"; then
-    uname_S=`uname -s`
-    case "$uname_S" in
-        Darwin)
-            TARGET_OS=darwin
-            ;;
-        OpenBSD)
-            TARGET_OS=openbsd
-            ;;
-        DragonFly)
-            TARGET_OS=dragonfly
-            ;;
-        FreeBSD)
-            TARGET_OS=freebsd
-            ;;
-        NetBSD)
-            TARGET_OS=netbsd
-            ;;
-        SunOS)
-            TARGET_OS=solaris
-            ;;
-        *)
-            TARGET_OS=linux
-            ;;
-    esac
-fi
-
-if test -z "$TARGET_ARCH"; then
-    uname_M=`uname -m`
-    case "$uname_M" in
-        x86_64)
-            TARGET_ARCH=amd64
-            ;;
-        arm32)
-            TARGET_ARCH=arm32
-            ;;
-        arm64)
-            TARGET_ARCH=arm64
-            ;;
-        ppc64*)
-            TARGET_ARCH=ppc64
-            ;;
-        aarch64)
-            TARGET_ARCH=arm
-            ;;
-        i386)
-            TARGET_ARCH=386
-            ;;
-        *)
-            TARGET_ARCH=amd64
-            ;;
-    esac
-fi
 
 GO_PROJECT=github.com/apache/kvrocks-controller
 BUILD_DIR=./_build
@@ -86,17 +32,9 @@ for TARGET_NAME in "$SERVER_TARGET_NAME" "$CLIENT_TARGET_NAME"; do
         CMD_PATH="${GO_PROJECT}/cmd/client"
     fi
 
-    if [[ "$BUILDER_IMAGE" == "none" ]]; then
-        GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" CGO_ENABLED=0 go build -v -ldflags \
-            "-X $GO_PROJECT/version.Version=$VERSION" \
-            -o ${TARGET_NAME} ${CMD_PATH}
-    else
-        docker run --rm --privileged -it -v $(pwd):/${TARGET_NAME} -w /${TARGET_NAME} \
-            -e GOOS="$TARGET_OS" -e GOARCH="$TARGET_ARCH" -e CGO_ENABLED=0 \
-            $BUILDER_IMAGE go build -v -ldflags \
-            "-X $GO_PROJECT/version.Version=$VERSION" \
-            -o /${TARGET_NAME}/${TARGET_NAME} ${CMD_PATH}
-    fi
+    GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" CGO_ENABLED=0 go build -v -ldflags \
+        "-X $GO_PROJECT/version.Version=$VERSION" \
+        -o ${TARGET_NAME} ${CMD_PATH}
 
     if [[ $? -ne 0 ]]; then
         echo "Failed to build $TARGET_NAME"


### PR DESCRIPTION
For most users, they don't need to have the cross-compilation,
and the script for detecting the OS and ARCH might be wrong in some niche operation systems.
So let's remove this and users can specify the GOOS/GOARCH environment explicitly if they want.

This closes #216