### PR TITLE
Add support of changing raft peers via HTTP api

### DIFF
--- a/consts/context_key.go
+++ b/consts/context_key.go
@@ -23,7 +23,7 @@ const (
 	ContextKeyStore        = "_context_key_storage"
 	ContextKeyCluster      = "_context_key_cluster"
 	ContextKeyClusterShard = "_context_key_cluster_shard"
-	ContextKeyHost         = "_context_key_host"
+	ContextKeyRaftNode     = "_context_key_raft_node"
 )
 
 const (

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -104,6 +104,7 @@ func (c *Controller) resume(ctx context.Context) error {
 		}
 		for _, cluster := range clusters {
 			c.addCluster(ns, cluster)
+			logger.Get().Debug("Resume the cluster", zap.String("namespace", ns), zap.String("cluster", cluster))
 		}
 	}
 	return nil

--- a/server/api/handler.go
+++ b/server/api/handler.go
@@ -20,13 +20,16 @@
 
 package api
 
-import "github.com/apache/kvrocks-controller/store"
+import (
+	"github.com/apache/kvrocks-controller/store"
+)
 
 type Handler struct {
 	Namespace *NamespaceHandler
 	Cluster   *ClusterHandler
 	Shard     *ShardHandler
 	Node      *NodeHandler
+	Raft      *RaftHandler
 }
 
 func NewHandler(s *store.ClusterStore) *Handler {
@@ -35,5 +38,6 @@ func NewHandler(s *store.ClusterStore) *Handler {
 		Cluster:   &ClusterHandler{s: s},
 		Shard:     &ShardHandler{s: s},
 		Node:      &NodeHandler{s: s},
+		Raft:      &RaftHandler{},
 	}
 }

--- a/server/api/raft.go
+++ b/server/api/raft.go
@@ -93,6 +93,7 @@ func (handler *RaftHandler) UpdatePeer(c *gin.Context) {
 	} else {
 		if _, ok := peers[req.ID]; !ok {
 			helper.ResponseBadRequest(c, errors.New("peer not exists"))
+			return
 		}
 		if len(peers) == 1 {
 			helper.ResponseBadRequest(c, errors.New("can't remove the last peer"))

--- a/server/api/raft.go
+++ b/server/api/raft.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apache/kvrocks-controller/consts"
+	"github.com/apache/kvrocks-controller/logger"
+	"github.com/apache/kvrocks-controller/server/helper"
+	"github.com/apache/kvrocks-controller/store/engine/raft"
+	"go.uber.org/zap"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	OperationAdd    = "add"
+	OperationRemove = "remove"
+)
+
+type RaftHandler struct{}
+
+type MemberRequest struct {
+	ID        uint64 `json:"id" validate:"required,gt=0"`
+	Operation string `json:"operation" validate:"required"`
+	Peer      string `json:"peer"`
+}
+
+func (r *MemberRequest) validate() error {
+	r.Operation = strings.ToLower(r.Operation)
+	if r.Operation != OperationAdd && r.Operation != OperationRemove {
+		return fmt.Errorf("operation must be one of [%s]",
+			strings.Join([]string{OperationAdd, OperationRemove}, ","))
+	}
+	if r.Operation == OperationAdd && r.Peer == "" {
+		return fmt.Errorf("peer should NOT be empty")
+	}
+	return nil
+}
+
+func (handler *RaftHandler) ListPeers(c *gin.Context) {
+	raftNode, _ := c.MustGet(consts.ContextKeyRaftNode).(*raft.Node)
+	peers := raftNode.ListPeers()
+	helper.ResponseOK(c, gin.H{"peers": peers})
+}
+
+func (handler *RaftHandler) UpdatePeer(c *gin.Context) {
+	var req MemberRequest
+	if err := c.BindJSON(&req); err != nil {
+		helper.ResponseBadRequest(c, err)
+		return
+	}
+	if err := req.validate(); err != nil {
+		helper.ResponseBadRequest(c, err)
+		return
+	}
+
+	raftNode, _ := c.MustGet(consts.ContextKeyRaftNode).(*raft.Node)
+	var err error
+	if req.Operation == OperationAdd {
+		err = raftNode.AddPeer(c, req.ID, req.Peer)
+	} else {
+		err = raftNode.RemovePeer(c, req.ID)
+	}
+	if err != nil {
+		helper.ResponseError(c, err)
+	} else {
+		logger.Get().With(zap.Any("request", req)).Info("Update peer success")
+		helper.ResponseOK(c, nil)
+	}
+}

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/apache/kvrocks-controller/store/engine/raft"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -66,7 +67,11 @@ func RedirectIfNotLeader(c *gin.Context) {
 		c.Abort()
 		return
 	}
-	if !storage.IsLeader() {
+
+	_, isRaftMode := storage.GetEngine().(*raft.Node)
+	// Raft engine will forward the request to the leader nod under the hood,
+	// so we don't need to do the redirect.
+	if !storage.IsLeader() && !isRaftMode {
 		if !c.GetBool(consts.HeaderIsRedirect) {
 			c.Set(consts.HeaderIsRedirect, true)
 			peerAddr := helper.ExtractAddrFromSessionID(storage.Leader())
@@ -129,5 +134,17 @@ func RequiredClusterShard(c *gin.Context) {
 
 	c.Set(consts.ContextKeyCluster, cluster)
 	c.Set(consts.ContextKeyClusterShard, shard)
+	c.Next()
+}
+
+func RequiredRaftEngine(c *gin.Context) {
+	storage, _ := c.MustGet(consts.ContextKeyStore).(*store.ClusterStore)
+	raftNode, ok := storage.GetEngine().(*raft.Node)
+	if !ok {
+		helper.ResponseBadRequest(c, errors.New("raft engine is not enabled"))
+		c.Abort()
+		return
+	}
+	c.Set(consts.ContextKeyRaftNode, raftNode)
 	c.Next()
 }

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -69,7 +69,7 @@ func RedirectIfNotLeader(c *gin.Context) {
 	}
 
 	_, isRaftMode := storage.GetEngine().(*raft.Node)
-	// Raft engine will forward the request to the leader nod under the hood,
+	// Raft engine will forward the request to the leader node under the hood,
 	// so we don't need to do the redirect.
 	if !storage.IsLeader() && !isRaftMode {
 		if !c.GetBool(consts.HeaderIsRedirect) {

--- a/server/route.go
+++ b/server/route.go
@@ -47,6 +47,13 @@ func (srv *Server) initHandlers() {
 
 	apiV1 := engine.Group("/api/v1/")
 	{
+		raftAPI := apiV1.Group("raft")
+		{
+			raftAPI.Use(middleware.RequiredRaftEngine)
+			raftAPI.POST("/peers", handler.Raft.UpdatePeer)
+			raftAPI.GET("/peers", handler.Raft.ListPeers)
+		}
+
 		namespaces := apiV1.Group("namespaces")
 		{
 			namespaces.GET("", handler.Namespace.List)

--- a/store/engine/engine.go
+++ b/store/engine/engine.go
@@ -17,6 +17,7 @@
  * under the License.
  *
  */
+
 package engine
 
 import (

--- a/store/engine/raft/config_test.go
+++ b/store/engine/raft/config_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestConfig_Validate(t *testing.T) {
 	c := &Config{}
+	c.init()
 
 	// missing ID
 	require.ErrorContains(t, c.validate(), "ID cannot be 0")
@@ -40,6 +41,12 @@ func TestConfig_Validate(t *testing.T) {
 	// ID greater than the number of peers
 	c.ID = 2
 	require.ErrorContains(t, c.validate(), "ID cannot be greater than the number of peers")
+
+	c.ID = 1
+	c.ClusterState = "invalid"
+	require.ErrorContains(t, c.validate(), "cluster state must be one of [new, existing]")
+	c.ClusterState = ClusterStateNew
+	require.NoError(t, c.validate())
 }
 
 func TestConfig_Init(t *testing.T) {

--- a/store/engine/raft/node.go
+++ b/store/engine/raft/node.go
@@ -166,7 +166,7 @@ func (n *Node) run() error {
 	n.snapshotIndex = snapshot.Metadata.Index
 	n.confState = snapshot.Metadata.ConfState
 
-	if n.config.Join || walExists {
+	if n.config.ClusterState == ClusterStateExisting || walExists {
 		n.raftNode = raft.RestartNode(raftConfig)
 	} else {
 		n.raftNode = raft.StartNode(raftConfig, peers)
@@ -175,6 +175,7 @@ func (n *Node) run() error {
 	if err := n.runTransport(); err != nil {
 		return err
 	}
+	n.watchLeaderChange()
 	return n.runRaftMessages()
 }
 
@@ -225,10 +226,33 @@ func (n *Node) runTransport() error {
 	return nil
 }
 
+func (n *Node) watchLeaderChange() {
+	n.wg.Add(1)
+	go func() {
+		defer n.wg.Done()
+
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-n.shutdown:
+				return
+			case <-ticker.C:
+				lead := n.GetRaftLead()
+				if lead != n.leader {
+					n.leader = lead
+					n.leaderChanged <- true
+					n.logger.Info("Found leader changed", zap.Uint64("leader", lead))
+				}
+			}
+		}
+	}()
+}
+
 func (n *Node) runRaftMessages() error {
 	n.wg.Add(1)
 	go func() {
-		ticker := time.NewTicker(100 * time.Millisecond)
+		ticker := time.NewTicker(time.Second)
 		defer func() {
 			ticker.Stop()
 			n.wg.Done()
@@ -253,9 +277,7 @@ func (n *Node) runRaftMessages() error {
 				if err := n.applySnapshot(rd.Snapshot); err != nil {
 					n.logger.Error("Failed to apply snapshot", zap.Error(err))
 				}
-				if len(rd.Entries) > 0 {
-					_ = n.dataStore.raftStorage.Append(rd.Entries)
-				}
+				_ = n.dataStore.raftStorage.Append(rd.Entries)
 
 				for _, msg := range rd.Messages {
 					if msg.Type == raftpb.MsgApp {
@@ -466,14 +488,14 @@ func (n *Node) applyEntry(entry raftpb.Entry) error {
 				n.peers.Store(cc.NodeID, string(cc.Context))
 			}
 		case raftpb.ConfChangeRemoveNode:
-			n.peers.Delete(cc.NodeID)
 			if cc.NodeID == n.config.ID {
+				n.logger.Info("I have been removed from the cluster, will shutdown")
 				n.Close()
-				n.logger.Info("Node removed from the cluster")
 				return nil
 			}
-			n.logger.Info("Remove the peer", zap.Uint64("node_id", cc.NodeID))
 			n.transport.RemovePeer(types.ID(cc.NodeID))
+			n.peers.Delete(cc.NodeID)
+			n.logger.Info("Remove the peer", zap.Uint64("node_id", cc.NodeID))
 		case raftpb.ConfChangeUpdateNode:
 			n.transport.UpdatePeer(types.ID(cc.NodeID), []string{string(cc.Context)})
 			if _, ok := n.peers.Load(cc.NodeID); ok {

--- a/store/engine/raft/node.go
+++ b/store/engine/raft/node.go
@@ -116,7 +116,7 @@ func (n *Node) Addr() string {
 }
 
 func (n *Node) ListPeers() map[uint64]string {
-	peers := make(map[uint64]string, 0)
+	peers := make(map[uint64]string)
 	n.peers.Range(func(key, value interface{}) bool {
 		id, _ := key.(uint64)
 		peer, _ := value.(string)

--- a/store/engine/raft/node_test.go
+++ b/store/engine/raft/node_test.go
@@ -54,6 +54,11 @@ func NewTestCluster(n int) *TestCluster {
 			HeartbeatSeconds: 1,
 			ElectionSeconds:  2,
 		})
+		// drain leader change events
+		go func() {
+			for range nodes[i].LeaderChange() {
+			}
+		}()
 	}
 	return &TestCluster{nodes: nodes}
 }

--- a/store/engine/raft/node_test.go
+++ b/store/engine/raft/node_test.go
@@ -68,7 +68,11 @@ func (c *TestCluster) createNode(peers []string) (*Node, error) {
 		HeartbeatSeconds: 1,
 		ElectionSeconds:  2,
 	})
-	return node, err
+	if err != nil {
+		return nil, err
+	}
+	c.nodes = append(c.nodes, node)
+	return node, nil
 }
 
 func (c *TestCluster) AddNode(ctx context.Context, nodeID uint64, peer string) error {
@@ -79,16 +83,18 @@ func (c *TestCluster) AddNode(ctx context.Context, nodeID uint64, peer string) e
 }
 
 func (c *TestCluster) RemoveNode(ctx context.Context, nodeID uint64) error {
+	var node *Node
 	for i, n := range c.nodes {
 		if n.config.ID == nodeID {
+			node = n
 			c.nodes = append(c.nodes[:i], c.nodes[i+1:]...)
 			break
 		}
 	}
-	if len(c.nodes) == 0 {
+	if len(c.nodes) == 0 || node == nil {
 		return nil
 	}
-	return c.nodes[0].RemovePeer(ctx, nodeID)
+	return node.RemovePeer(ctx, nodeID)
 }
 
 func (c *TestCluster) SetSnapshotThreshold(threshold uint64) {
@@ -234,13 +240,13 @@ func TestCluster_AddRemovePeer(t *testing.T) {
 			got, _ := n1.Get(ctx, "foo")
 			return string(got) == "bar-1"
 		}, 1*time.Second, 100*time.Millisecond)
-		require.Len(t, n1.Peers(), 4)
+		require.Len(t, n1.ListPeers(), 4)
 	})
 
 	t.Run("remove a peer node", func(t *testing.T) {
 		cluster.RemoveNode(ctx, 4)
 		require.Eventually(t, func() bool {
-			return len(n1.Peers()) == 3
+			return len(n1.ListPeers()) == 3
 		}, 10*time.Second, 100*time.Millisecond)
 	})
 }

--- a/store/engine/raft/store_test.go
+++ b/store/engine/raft/store_test.go
@@ -97,10 +97,10 @@ func TestDataStore(t *testing.T) {
 		entries = store.List("ba")
 		require.Len(t, entries, 4)
 
-		entries = store.List("bar-2")
-		require.Len(t, entries, 1)
+		entries = store.List("bar")
+		require.Len(t, entries, 2)
 
-		entries = store.List("foo")
+		entries = store.List("fo")
 		require.Len(t, entries, 1)
 
 		store.Delete("bar-2")

--- a/store/store.go
+++ b/store/store.go
@@ -310,6 +310,10 @@ func (s *ClusterStore) EmitEvent(event EventPayload) {
 	s.eventNotifyCh <- event
 }
 
+func (s *ClusterStore) GetEngine() engine.Engine {
+	return s.e
+}
+
 func (s *ClusterStore) LeaderChange() <-chan bool {
 	return s.e.LeaderChange()
 }


### PR DESCRIPTION
This closes #231.

I have tested the basic features manually for the raft engine:

Step 1: start a cluster with three nodes:

```JSON
❯ curl -s  http://127.0.0.1:9379/api/v1/raft/peers | jq    

{                                                                       
  "data": {
    "leader": 1,
    "peers": {
      "1": "http://127.0.0.1:6001",
      "2": "http://127.0.0.1:6002",
      "3": "http://127.0.0.1:6003"
    }
  }
}
```

Step 2: add a new peer node into the cluster:

```JSON
❯ curl -XPOST -d '{"id":4,"peer":"http://127.0.0.1:6004","operation":"add"}'  http://127.0.0.1:9379/api/v1/raft/peers

❯ curl -s  http://127.0.0.1:9379/api/v1/raft/peers | jq    

{
  "data": {
    "leader": 1,
    "peers": {
      "1": "http://127.0.0.1:6001",
      "2": "http://127.0.0.1:6002",
      "3": "http://127.0.0.1:6003",
      "4": "http://127.0.0.1:6004"
    }
  }
}
```

Step 3: remove a peer node from the cluster:

```JSON
❯ curl -XPOST -d '{"id":2,"operation":"remove"}'  http://127.0.0.1:9379/api/v1/raft/peers


❯ curl -s  http://127.0.0.1:9379/api/v1/raft/peers | jq
{
  "data": {
    "leader": 1,
    "peers": {
      "1": "http://127.0.0.1:6001",
      "3": "http://127.0.0.1:6003",
      "4": "http://127.0.0.1:6004"
    }
  }
}
```
