### PR TITLE
Relax the cluster version check when updating the cluster

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -180,7 +180,7 @@ func (s *ClusterStore) UpdateCluster(ctx context.Context, ns string, clusterInfo
 	if err != nil {
 		return err
 	}
-	if oldCluster.Version.Load() != clusterInfo.Version.Load() {
+	if oldCluster.Version.Load() > clusterInfo.Version.Load() {
 		return fmt.Errorf("the cluster has been updated by others")
 	}
 
@@ -212,7 +212,7 @@ func (s *ClusterStore) SetCluster(ctx context.Context, ns string, clusterInfo *C
 	if err != nil {
 		return err
 	}
-	if oldCluster.Version.Load() != clusterInfo.Version.Load() {
+	if oldCluster.Version.Load() > clusterInfo.Version.Load() {
 		return fmt.Errorf("the cluster has been updated by others")
 	}
 


### PR DESCRIPTION
Before this PR, we required the cluster shouldn't be modified when updating, but users might modify the cluster information via the Redis client during this period. To allow this, we only check if the current version is newer than the store.

This closes #220