### PR TITLE
Bump golang to 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.23
 
       - name: Checkout Code Base
         uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go-version: [1.22, stable]
+        go-version: [1.23, stable]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -454,7 +454,7 @@ linters-settings:
 
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.19"
+    go: "1.23"
 
   whitespace:
     multi-if: false   # Enforces newlines (or comments) after every multi-line if statement

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM golang:1.20 as build
+FROM golang:1.23 as build
 
 WORKDIR /kvctl
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/apache/kvrocks-controller
 
-go 1.22
+go 1.23
 
-toolchain go1.22.9
+toolchain go1.23.4
 
 require (
 	github.com/fatih/color v1.16.0


### PR DESCRIPTION
Use latest stable Go version 1.23 (1.23.4)

**Changed**:

- golang version in CI 
- golangci-lint fix linter unused
- Dockerfile - build image changed to golang:1.23
- go.mod change go version and toolchain version (Important: no package/deps updated at this release)