### PR TITLE
ci: update github actions to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Base
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -37,12 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
 
       - name: Checkout Code Base
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
 
   build-test:
     name: Build and test
-    needs: [lint]
+    needs: [license-check, lint]
     strategy:
       matrix:
         go-version: [1.23, stable]
@@ -71,12 +71,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{matrix.go-version}}
 
       - name: Checkout Code Base
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,18 @@ name: CI Actions  # don't edit while the badge was depend on this
 on: [push, pull_request]
 
 jobs:
+  license-check:
+    name: License check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: apache/skywalking-eyes/header@v0.6.0
+        with:
+          config: .github/config/licenserc.yaml
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -33,10 +45,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - uses: apache/skywalking-eyes/header@v0.6.0
-        with:
-          config: .github/config/licenserc.yaml
 
       - name: Restore Go Module Cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore Go Module Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
@@ -81,7 +81,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore Go Module Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
@@ -95,7 +95,7 @@ jobs:
         run: make test
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.out
           flags: unittests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: apache/skywalking-eyes/header@v0.4.0
+      - uses: apache/skywalking-eyes/header@v0.6.0
         with:
           config: .github/config/licenserc.yaml
 


### PR DESCRIPTION
Reorder actions with splitting lint into two separate job: license checking and lint code. Because in old style, skywalking-eyes job replace Go version for next job (lint) into own (e.g. 1.19 without go toolchain support and produce many error).

Other changes

- bump apache/skywalking-eyes to v0.6.0
- bump actions/setup-go to v0.5
- bump actions/checkout to v4
- bump actions/cache to v4
- bump codecov/codecov-action to v5 