### PR TITLE
Fix typo in the main UI heading

### DIFF
--- a/store/engine/engine_inmemory.go
+++ b/store/engine/engine_inmemory.go
@@ -75,7 +75,7 @@ func (m *Mock) List(_ context.Context, prefix string) ([]Entry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	exists := make(map[string]bool, 0)
+	exists := map[string]bool{}
 	var entries []Entry
 	for k, v := range m.values {
 		if strings.HasPrefix(k, prefix) {

--- a/store/engine/engine_inmemory.go
+++ b/store/engine/engine_inmemory.go
@@ -75,7 +75,7 @@ func (m *Mock) List(_ context.Context, prefix string) ([]Entry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	exists := map[string]bool{}
+	exists := make(map[string]bool, 0)
 	var entries []Entry
 	for k, v := range m.values {
 		if strings.HasPrefix(k, prefix) {

--- a/webui/src/app/page.tsx
+++ b/webui/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
             style={{minHeight: 'calc(100vh - 64px)', height: 'calc(100vh - 64px)'}}
             className={'flex flex-col items-center justify-center space-y-2 h-full'}
         >
-            <Typography variant="h3">Kvrocks Controler UI</Typography>
+            <Typography variant="h3">Kvrocks Controller UI</Typography>
             <Typography variant="body1">Work in progress...</Typography>
             <Button size="large" variant="outlined" sx={{ textTransform: 'none' }} href="https://github.com/apache/kvrocks-controller/issues/135">
                 Click here to submit your suggestions


### PR DESCRIPTION
There's a typo in the main UI heading - "Controler" should be "Controller". This typo appears on the homepage of the web UI, making it very visible to users.