### PR TITLE
Limit concurrent goroutines in cluster node probing

### DIFF
--- a/controller/cluster.go
+++ b/controller/cluster.go
@@ -194,9 +194,20 @@ func (c *ClusterChecker) syncClusterToNodes(ctx context.Context) error {
 }
 
 func (c *ClusterChecker) parallelProbeNodes(ctx context.Context, cluster *store.Cluster) {
+	// Limit concurrent operations to a reasonable number
+	semaphore := make(chan struct{}, 20) // Adjust based on expected deployment size
+	var wg sync.WaitGroup
+
 	for i, shard := range cluster.Shards {
 		for _, node := range shard.Nodes {
+			wg.Add(1)
 			go func(shardIdx int, n store.Node) {
+				defer wg.Done()
+
+				// Acquire semaphore
+				semaphore <- struct{}{}
+				defer func() { <-semaphore }()
+
 				log := logger.Get().With(
 					zap.String("id", n.ID()),
 					zap.Bool("is_master", n.IsMaster()),
@@ -233,6 +244,9 @@ func (c *ClusterChecker) parallelProbeNodes(ctx context.Context, cluster *store.
 			}(i, node)
 		}
 	}
+
+	// Optional: wait for all probes to complete
+	wg.Wait()
 }
 
 func (c *ClusterChecker) probeLoop() {

--- a/store/engine/engine_inmemory.go
+++ b/store/engine/engine_inmemory.go
@@ -75,7 +75,7 @@ func (m *Mock) List(_ context.Context, prefix string) ([]Entry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	exists := make(map[string]bool, 0)
+	exists := map[string]bool{}
 	var entries []Entry
 	for k, v := range m.values {
 		if strings.HasPrefix(k, prefix) {

--- a/store/engine/engine_inmemory.go
+++ b/store/engine/engine_inmemory.go
@@ -75,7 +75,7 @@ func (m *Mock) List(_ context.Context, prefix string) ([]Entry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	exists := map[string]bool{}
+	exists := make(map[string]bool, 0)
 	var entries []Entry
 	for k, v := range m.values {
 		if strings.HasPrefix(k, prefix) {

--- a/webui/src/app/page.tsx
+++ b/webui/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
             style={{minHeight: 'calc(100vh - 64px)', height: 'calc(100vh - 64px)'}}
             className={'flex flex-col items-center justify-center space-y-2 h-full'}
         >
-            <Typography variant="h3">Kvrocks Controler UI</Typography>
+            <Typography variant="h3">Kvrocks Controller UI</Typography>
             <Typography variant="body1">Work in progress...</Typography>
             <Button size="large" variant="outlined" sx={{ textTransform: 'none' }} href="https://github.com/apache/kvrocks-controller/issues/135">
                 Click here to submit your suggestions


### PR DESCRIPTION
Right now, parallelProbeNodes() creates a new goroutine for every node without any limit.. In large clusters with hundreds or thousands of nodes, this can cause serious issues like:
•	Too many goroutines → Can overwhelm system resources..
•	Network overload → All probes run at once, causing congestion
•	No completion guarantee → function exits without ensuring all probes are done
Solution: adding a semaphore..

to fix this, we introduce a semaphore a channel with a fixed limit to control how many probes run at the same time. this prevents system overload while still keeping things parallel...

how it works:
	•	Limits concurrent probes (e.g., max 20 at a time)
	•	Uses WaitGroup to ensure all probes finish before returning
	•	releases a semaphore slot after each probe completes

this makes the system more stable scalable, and production-ready preventing resource exhaustion while keeping parallel execution efficient. 
