### PR TITLE
fix consul engine bug when calling Set and List

### DIFF
--- a/config/config-consul.yaml
+++ b/config/config-consul.yaml
@@ -16,8 +16,7 @@
 # under the License.
 #
 
-addr: "127.0.0.1:8500"
-
+addr: "127.0.0.1:9379"
 
 # Which store engine should be used by controller
 # options: etcd, zookeeper, raft, consul
@@ -40,7 +39,6 @@ controller:
   failover:
     ping_interval_seconds: 3
     min_alive_size: 5
-
 # Uncomment this part to save logs to filename instead of stdout
 #log:
 #  level: info

--- a/store/engine/consul/consul.go
+++ b/store/engine/consul/consul.go
@@ -318,7 +318,9 @@ func (c *Consul) Close() error {
 
 func sanitizeKey(key string) string {
 	if len(key) > 0 && key[0] == '/' {
-		key = strings.TrimPrefix("key", "/")
+		fmt.Printf("sanitizing: %v \n", key)
+		key = strings.TrimPrefix(key, "/")
+		fmt.Printf("sanitized:: %v \n", key)
 	}
 	return key
 }

--- a/store/engine/consul/consul.go
+++ b/store/engine/consul/consul.go
@@ -191,6 +191,7 @@ func (c *Consul) Set(ctx context.Context, key string, value []byte) error {
 		Key:   key,
 		Value: value,
 	}
+	fmt.Printf("CONSUL SET: key: %v, value: %s\n", key, value)
 	_, err := c.client.KV().Put(kvPair, nil)
 	return err
 }

--- a/store/engine/consul/consul.go
+++ b/store/engine/consul/consul.go
@@ -184,6 +184,10 @@ func (c *Consul) Exists(ctx context.Context, key string) (bool, error) {
 }
 
 func (c *Consul) Set(ctx context.Context, key string, value []byte) error {
+	fmt.Printf("calling set: %v, %s\n", key, value)
+	if len(key) > 0 && key[0] == '/' {
+		key, _ = strings.CutPrefix(key, "/")
+	}
 	kvPair := &api.KVPair{
 		Key:   key,
 		Value: value,
@@ -236,7 +240,6 @@ func (c *Consul) electLoop() {
 			TTL:       fmt.Sprintf("%v", sessionTTL),
 			LockDelay: lockDelay,
 		}, nil)
-
 		if err != nil {
 			logger.Get().With(
 				zap.Error(err),

--- a/store/engine/consul/consul.go
+++ b/store/engine/consul/consul.go
@@ -162,6 +162,7 @@ func (c *Consul) IsReady(ctx context.Context) bool {
 }
 
 func (c *Consul) Get(ctx context.Context, key string) ([]byte, error) {
+	key = sanitizeKey(key)
 	rsp, _, err := c.client.KV().Get(key, nil)
 	if err != nil {
 		return nil, err
@@ -173,6 +174,7 @@ func (c *Consul) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (c *Consul) Exists(ctx context.Context, key string) (bool, error) {
+	key = sanitizeKey(key)
 	_, err := c.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, consts.ErrNotFound) {
@@ -184,10 +186,7 @@ func (c *Consul) Exists(ctx context.Context, key string) (bool, error) {
 }
 
 func (c *Consul) Set(ctx context.Context, key string, value []byte) error {
-	fmt.Printf("calling set: %v, %s\n", key, value)
-	if len(key) > 0 && key[0] == '/' {
-		key, _ = strings.CutPrefix(key, "/")
-	}
+	key = sanitizeKey(key)
 	kvPair := &api.KVPair{
 		Key:   key,
 		Value: value,
@@ -197,6 +196,7 @@ func (c *Consul) Set(ctx context.Context, key string, value []byte) error {
 }
 
 func (c *Consul) Delete(ctx context.Context, key string) error {
+	key = sanitizeKey(key)
 	_, err := c.client.KV().Delete(key, nil)
 	return err
 }
@@ -314,4 +314,11 @@ func (c *Consul) Close() error {
 	c.wg.Wait()
 	c.client = nil
 	return nil
+}
+
+func sanitizeKey(key string) string {
+	if len(key) > 0 && key[0] == '/' {
+		key = strings.TrimPrefix("key", "/")
+	}
+	return key
 }

--- a/store/engine/consul/consul.go
+++ b/store/engine/consul/consul.go
@@ -191,7 +191,6 @@ func (c *Consul) Set(ctx context.Context, key string, value []byte) error {
 		Key:   key,
 		Value: value,
 	}
-	fmt.Printf("CONSUL SET: key: %v, value: %s\n", key, value)
 	_, err := c.client.KV().Put(kvPair, nil)
 	return err
 }

--- a/store/engine/consul/consul.go
+++ b/store/engine/consul/consul.go
@@ -202,6 +202,7 @@ func (c *Consul) Delete(ctx context.Context, key string) error {
 }
 
 func (c *Consul) List(ctx context.Context, prefix string) ([]engine.Entry, error) {
+	prefix = sanitizeKey(prefix)
 	rsp, _, err := c.client.KV().List(prefix, nil)
 	if err != nil {
 		return nil, err
@@ -213,7 +214,7 @@ func (c *Consul) List(ctx context.Context, prefix string) ([]engine.Entry, error
 		if string(kv.Key) == prefix {
 			continue
 		}
-		key := strings.TrimLeft(string(kv.Key[prefixLen+1]), "/")
+		key := strings.TrimLeft(string(kv.Key[prefixLen+1:]), "/")
 		if strings.ContainsRune(key, '/') {
 			continue
 		}
@@ -318,9 +319,7 @@ func (c *Consul) Close() error {
 
 func sanitizeKey(key string) string {
 	if len(key) > 0 && key[0] == '/' {
-		fmt.Printf("sanitizing: %v \n", key)
 		key = strings.TrimPrefix(key, "/")
-		fmt.Printf("sanitized:: %v \n", key)
 	}
 	return key
 }

--- a/store/engine/consul/consul_test.go
+++ b/store/engine/consul/consul_test.go
@@ -47,7 +47,7 @@ func TestBasicOperations(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	keys := []string{"a/b/c0", "a/b/c1", "a/b/c2"}
+	keys := []string{"/a/b/c0", "/a/b/c1", "/a/b/c2"}
 	value := []byte("v")
 	for _, key := range keys {
 		require.NoError(t, persist.Set(ctx, key, value))
@@ -55,7 +55,7 @@ func TestBasicOperations(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, value, gotValue)
 	}
-	entries, err := persist.List(ctx, "a/b")
+	entries, err := persist.List(ctx, "/a/b")
 	require.NoError(t, err)
 	require.Equal(t, len(keys), len(entries))
 	for _, key := range keys {


### PR DESCRIPTION
This PR fixes two bugs with the Consul Engine Implementation

1. When trying to run the example with consul as the engine, I get an error about the key starting with a `/`
```sh
./_build/kvctl create namespace test-ns
error: Invalid key. Key must not begin with a '/': /kvrocks/metadata/test-ns
```
2. Listing values from consul only produces 1 character results
```sh
./_build/kvctl list namespaces
t 
```



### Setup

```sh
# running setup for the consul and other engines
make setup

# on another 3 terminals, I'm running 3 instances of kvrocks
./build/kvrocks -c kvrocks.conf --cluster-enabled yes --port 6001 --dir /tmp/kvrocks1
./build/kvrocks -c kvrocks.conf --cluster-enabled yes --port 6002 --dir /tmp/kvrocks1
./build/kvrocks -c kvrocks.conf --cluster-enabled yes --port 6003 --dir /tmp/kvrocks1

# run kvctl-server with config-consul, with the addr modified:  addr: "127.0.0.1:9379"
./_build/kvctl-server -c config/config-consul.yaml

# BUG 1
./_build/kvctl create namespace test-ns
error: Invalid key. Key must not begin with a '/': /kvrocks/metadata/test-ns

# after fixing bug 1, continuing with the example and listing the namespace
# BUG 2
./_build/kvctl list namespaces
t
```