### PR TITLE
Fix npm build error and build web ui in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,9 @@ jobs:
       - name: Build
         run: make
 
+      - name: Build Web UI
+        run: cd webui && npm install && npm run build
+
       - name: Make Test
         run: make test
 

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx
@@ -116,10 +116,10 @@ export default function Cluster({ params }: { params: { namespace: string; clust
                                                 label: `${shard.nodes.length} nodes`,
                                                 color: "secondary",
                                             },
-                                            shard.migrating_slot >= 0
-                                                ? { label: "Migrating", color: "warning" }
-                                                : undefined,
-                                        ].filter(Boolean)}
+                                            ...(shard.migrating_slot >= 0
+                                                ? [{ label: "Migrating", color: "warning" }]
+                                                : []),
+                                        ]}
                                     >
                                         <div className="space-y-2 text-sm">
                                             <div className="flex justify-between">

--- a/webui/src/app/not-found.tsx
+++ b/webui/src/app/not-found.tsx
@@ -42,7 +42,7 @@ export default function NotFound() {
                 </Typography>
 
                 <Typography variant="body1" className="mb-8 text-gray-600 dark:text-gray-300">
-                    We couldn't find the page you're looking for. It might have been moved, deleted,
+                    We couldn&apos;t find the page you&apos;re looking for. It might have been moved, deleted,
                     or never existed.
                 </Typography>
 

--- a/webui/src/app/not-found.tsx
+++ b/webui/src/app/not-found.tsx
@@ -42,8 +42,8 @@ export default function NotFound() {
                 </Typography>
 
                 <Typography variant="body1" className="mb-8 text-gray-600 dark:text-gray-300">
-                    We couldn&apos;t find the page you&apos;re looking for. It might have been moved, deleted,
-                    or never existed.
+                    We couldn&apos;t find the page you&apos;re looking for. It might have been
+                    moved, deleted, or never existed.
                 </Typography>
 
                 <div className="flex flex-wrap justify-center gap-4">


### PR DESCRIPTION
Before this PR, running `npm run build` would return the following error:

```shell
./src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx:114:41
Type error: Type '({ label: string; color: string; } | undefined)[]' is not assignable to type '{ label: string; color?: string | undefined; }[]'.
  Type '{ label: string; color: string; } | undefined' is not assignable to type '{ label: string; color?: string | undefined; }'.
    Type 'undefined' is not assignable to type '{ label: string; color?: string | undefined; }'.

  112 |                                     <ResourceCard
  113 |                                         title={`Shard ${index + 1}`}
> 114 |                                         tags={[
      |                                         ^
  115 |                                             {
  116 |                                                 label: `${shard.nodes.length} nodes`,
  117 |                                                 color: "secondary",

```

It's due to using the array filter on an undefined value.