### PR TITLE
sync cluster info to nodes concurrently

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/apache/kvrocks-controller/logger"
+	"go.uber.org/zap"
 	"sync"
 
 	"github.com/apache/kvrocks-controller/consts"
@@ -192,6 +194,7 @@ func (s *ClusterStore) UpdateCluster(ctx context.Context, ns string, clusterInfo
 	if err := s.e.Set(ctx, buildClusterKey(ns, clusterInfo.Name), clusterBytes); err != nil {
 		return err
 	}
+	logger.Get().With(zap.String("cluster_info", string(clusterBytes))).Info("cluster version updated")
 
 	s.EmitEvent(EventPayload{
 		Namespace: ns,

--- a/store/store.go
+++ b/store/store.go
@@ -194,7 +194,7 @@ func (s *ClusterStore) UpdateCluster(ctx context.Context, ns string, clusterInfo
 	if err := s.e.Set(ctx, buildClusterKey(ns, clusterInfo.Name), clusterBytes); err != nil {
 		return err
 	}
-	logger.Get().With(zap.String("cluster_info", string(clusterBytes))).Info("cluster version updated")
+	logger.Get().With(zap.String("cluster_info", string(clusterBytes))).Info("Updated the cluster version")
 
 	s.EmitEvent(EventPayload{
 		Namespace: ns,


### PR DESCRIPTION
if a node syncs failed, all nodes behind it won't be synced 
to avoid it, sync cluster info to nodes in goroutines