### PR TITLE
Require CI must be passed before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,6 +38,8 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         required_approving_review_count: 1
+      required_status_checks:
+        strict: true
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
For now, the PR can be merged without passing CI, and it's not an expected behavior.