### PR TITLE
chore: enable dismiss_stale_reviews in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,7 +36,7 @@ github:
   protected_branches:
     unstable:
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
+        dismiss_stale_reviews: true
         required_approving_review_count: 1
       required_status_checks:
         strict: true


### PR DESCRIPTION
So that reviewers can be aware of new commits in a PR.