### PR TITLE
failover command previously gave EOF

### DIFF
--- a/cmd/client/command/failover.go
+++ b/cmd/client/command/failover.go
@@ -84,6 +84,9 @@ func failoverShard(client *client, options *FailoverOptions, shardIndex int) err
 		SetPathParam("namespace", options.namespace).
 		SetPathParam("cluster", options.cluster).
 		SetPathParam("shard", strconv.Itoa(shardIndex)).
+		SetBody(map[string]interface{}{
+			"preferred_node_id": options.preferred,
+		}).
 		Post("/namespaces/{namespace}/clusters/{cluster}/shards/{shard}/failover")
 	if err != nil {
 		return err


### PR DESCRIPTION
```sh
./_build/kvctl failover shard 1 -n test-ns -c test-cluster0 --preferred amzFeDtPXNLPwWHIeG7Ip50cDUJT0bH1O0uYwjm7
error: EOF
```

after fix
```sh
./_build/kvctl failover shard 1 -n test-ns -c test-cluster0 --preferred amzFeDtPXNLPwWHIeG7Ip50cDUJT0bH1O0uYwjm7
failover shard 1 successfully, new master id: amzFeDtPXNLPwWHIeG7Ip50cDUJT0bH1O0uYwjm7.
```

ShouldBindJSON would give an error `EOF` because `preferred_node_id` was not in the body
https://github.com/apache/kvrocks-controller/blob/unstable/server/api/shard.go#L125