### PR TITLE
Marshal the value into the null value if the slot is not migrating

### DIFF
--- a/store/cluster_shard.go
+++ b/store/cluster_shard.go
@@ -37,7 +37,6 @@ const (
 	// the old migrating slot was denoted by an int and -1 was
 	// used to denote a non migrating slot
 	NotMigratingInt = -1
-	NotMigratingString = "-1"
 )
 
 type Shard struct {

--- a/store/cluster_shard.go
+++ b/store/cluster_shard.go
@@ -37,6 +37,7 @@ const (
 	// the old migrating slot was denoted by an int and -1 was
 	// used to denote a non migrating slot
 	NotMigratingInt = -1
+	NotMigratingString = "-1"
 )
 
 type Shard struct {

--- a/store/slot.go
+++ b/store/slot.go
@@ -230,10 +230,10 @@ func (s *MigratingSlot) MarshalJSON() ([]byte, error) {
 		// backwards compatibility. When we read from an old cluster that had `-1`
 		// denoting !isMigrating. The MigratingSlot field will not be nil. So when
 		// this field is marshal'd back into JSON format, we can keep it as it was
-		// which was `-1`.
+		// which was "-1".
 		// The only case this turns back to null is if a migration happens on this
 		// shard, and the function `ClearMigrateState()` is called on the shard.
-		return json.Marshal(NotMigratingInt)
+		return json.Marshal(NotMigratingString)
 	}
 	return json.Marshal(s.String())
 }

--- a/store/slot.go
+++ b/store/slot.go
@@ -227,13 +227,7 @@ func (s *MigratingSlot) UnmarshalJSON(data []byte) error {
 
 func (s *MigratingSlot) MarshalJSON() ([]byte, error) {
 	if !s.IsMigrating {
-		// backwards compatibility. When we read from an old cluster that had `-1`
-		// denoting !isMigrating. The MigratingSlot field will not be nil. So when
-		// this field is marshal'd back into JSON format, we can keep it as it was
-		// which was "-1".
-		// The only case this turns back to null is if a migration happens on this
-		// shard, and the function `ClearMigrateState()` is called on the shard.
-		return json.Marshal(NotMigratingString)
+		return json.Marshal(nil)
 	}
 	return json.Marshal(s.String())
 }

--- a/store/slot_test.go
+++ b/store/slot_test.go
@@ -94,17 +94,15 @@ func TestMigratingSlot_MarshalUnmarshalJSON(t *testing.T) {
 	migratingSlot = MigratingSlot{SlotRange: SlotRange{Start: 0, Stop: 0}, IsMigrating: false}
 	migratingSlotBytes, err = json.Marshal(&migratingSlot)
 	require.NoError(t, err)
-	err = json.Unmarshal(migratingSlotBytes, &migratingSlot)
-	require.NoError(t, err)
-	assert.Equal(t, MigratingSlot{SlotRange{Start: 0, Stop: 0}, false}, migratingSlot)
+	// null []byte equal
+	assert.Equal(t, []byte{0x6e, 0x75, 0x6c, 0x6c}, migratingSlotBytes)
 
 	// same test as earlier, but checks that it resets the start and stop
 	migratingSlot = MigratingSlot{SlotRange: SlotRange{Start: 5, Stop: 5}, IsMigrating: false}
 	migratingSlotBytes, err = json.Marshal(&migratingSlot)
 	require.NoError(t, err)
-	err = json.Unmarshal(migratingSlotBytes, &migratingSlot)
-	require.NoError(t, err)
-	assert.Equal(t, MigratingSlot{SlotRange{Start: 0, Stop: 0}, false}, migratingSlot, "expects start and stop to reset to 0")
+	// null []byte equal
+	assert.Equal(t, []byte{0x6e, 0x75, 0x6c, 0x6c}, migratingSlotBytes)
 }
 
 // TestMigratingSlot_MarshalJSON will checks the resulting string

--- a/store/slot_test.go
+++ b/store/slot_test.go
@@ -95,7 +95,7 @@ func TestMigratingSlot_MarshalUnmarshalJSON(t *testing.T) {
 	migratingSlotBytes, err = json.Marshal(&migratingSlot)
 	require.NoError(t, err)
 	// null []byte equal
-	assert.Equal(t, []byte{0x6e, 0x75, 0x6c, 0x6c}, migratingSlotBytes)
+	assert.Equal(t, "null", string(migratingSlotBytes))
 
 	// same test as earlier, but checks that it resets the start and stop
 	migratingSlot = MigratingSlot{SlotRange: SlotRange{Start: 5, Stop: 5}, IsMigrating: false}

--- a/store/slot_test.go
+++ b/store/slot_test.go
@@ -102,7 +102,7 @@ func TestMigratingSlot_MarshalUnmarshalJSON(t *testing.T) {
 	migratingSlotBytes, err = json.Marshal(&migratingSlot)
 	require.NoError(t, err)
 	// null []byte equal
-	assert.Equal(t, []byte{0x6e, 0x75, 0x6c, 0x6c}, migratingSlotBytes)
+	assert.Equal(t, "null", string(migratingSlotBytes))
 }
 
 // TestMigratingSlot_MarshalJSON will checks the resulting string

--- a/store/slot_test.go
+++ b/store/slot_test.go
@@ -122,7 +122,7 @@ func TestMigratingSlot_MarshalJSON(t *testing.T) {
 	migratingSlot = MigratingSlot{SlotRange: SlotRange{Start: 5, Stop: 10}, IsMigrating: false}
 	migratingSlotBytes, err = json.Marshal(&migratingSlot)
 	require.NoError(t, err)
-	assert.Equal(t, `-1`, string(migratingSlotBytes))
+	assert.Equal(t, `null`, string(migratingSlotBytes))
 }
 
 func TestMigrateSlotRange_MarshalAndUnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
we read from an old cluster that had `-1` denoting !isMigrating, but new cluster migrating_slot value is string type. so we should return "-1" is not -1.