### PR TITLE
fix the data race when migrating slots on multi shards

### DIFF
--- a/controller/cluster.go
+++ b/controller/cluster.go
@@ -357,7 +357,7 @@ func (c *ClusterChecker) tryUpdateMigrationStatus(ctx context.Context, clonedClu
 		case "fail":
 			migratingSlot := shard.MigratingSlot
 			clonedCluster.Shards[i].ClearMigrateState()
-			if err := c.clusterStore.SetCluster(ctx, c.namespace, clonedCluster); err != nil {
+			if err := c.clusterStore.UpdateCluster(ctx, c.namespace, clonedCluster); err != nil {
 				log.Error("Failed to update the cluster", zap.Error(err))
 				return
 			}
@@ -372,13 +372,14 @@ func (c *ClusterChecker) tryUpdateMigrationStatus(ctx context.Context, clonedClu
 			clonedCluster.Shards[i].ClearMigrateState()
 			if err := c.clusterStore.UpdateCluster(ctx, c.namespace, clonedCluster); err != nil {
 				log.Error("Failed to update the cluster", zap.Error(err))
+				return
 			} else {
 				log.Info("Migrate the slot successfully", zap.String("slot", migratedSlot.String()))
 			}
 			c.updateCluster(clonedCluster)
 		default:
 			clonedCluster.Shards[i].ClearMigrateState()
-			if err := c.clusterStore.SetCluster(ctx, c.namespace, clonedCluster); err != nil {
+			if err := c.clusterStore.UpdateCluster(ctx, c.namespace, clonedCluster); err != nil {
 				log.Error("Failed to update the cluster", zap.Error(err))
 				return
 			}

--- a/server/api/cluster.go
+++ b/server/api/cluster.go
@@ -153,12 +153,7 @@ func (handler *ClusterHandler) MigrateSlot(c *gin.Context) {
 		return
 	}
 
-	if req.SlotOnly {
-		err = handler.s.UpdateCluster(c, namespace, cluster)
-	} else {
-		// The version should be increased after the slot migration is done
-		err = handler.s.SetCluster(c, namespace, cluster)
-	}
+	err = handler.s.UpdateCluster(c, namespace, cluster)
 	if err != nil {
 		helper.ResponseError(c, err)
 		return

--- a/store/cluster_mock_node.go
+++ b/store/cluster_mock_node.go
@@ -39,7 +39,7 @@ func NewClusterMockNode() *ClusterMockNode {
 }
 
 func (mock *ClusterMockNode) GetClusterNodeInfo(ctx context.Context) (*ClusterNodeInfo, error) {
-	return &ClusterNodeInfo{Sequence: mock.Sequence}, nil
+	return &ClusterNodeInfo{Sequence: mock.Sequence, Role: mock.role}, nil
 }
 
 func (mock *ClusterMockNode) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {


### PR DESCRIPTION
the cluster in MigrateSlot API(api/cluster.go) is different from cluster in tryUpdateMigrationStatus(controller/cluster.go).

Because of SetCluster method will not increment the verison, when doing migration on multi shards invoked by MigrateSlot API, the migration info will be overwrote by UpdateCluster mehtod.