### PR TITLE
Fix leader change haven't updated prevTermLeader when lost the leader

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -127,8 +127,8 @@ func (c *Controller) syncLoop(ctx context.Context) {
 	prevTermLeader := ""
 	if c.clusterStore.IsLeader() {
 		c.becomeLeader(ctx, prevTermLeader)
-		prevTermLeader = c.clusterStore.ID()
 	}
+	prevTermLeader = c.clusterStore.Leader()
 
 	c.readyCh <- struct{}{}
 	for {
@@ -144,6 +144,7 @@ func (c *Controller) syncLoop(ctx context.Context) {
 					continue
 				}
 				c.suspend()
+				prevTermLeader = c.clusterStore.Leader()
 				logger.Get().Warn("Lost the leader, suspend the controller")
 			}
 		case <-c.closeCh:


### PR DESCRIPTION
When deploying multiple controllers, the old leader lost the leader doesn't update the preTermLeader information. This will cause later leader resume cannot be accessed.

			if c.clusterStore.IsLeader() {
				if prevTermLeader != c.clusterStore.ID() {
					c.becomeLeader(ctx, prevTermLeader)
					prevTermLeader = c.clusterStore.ID()
				}
			} else {
				if prevTermLeader != c.clusterStore.ID() {
					continue
				}
				c.suspend()
				prevTermLeader = c.clusterStore.Leader()
				logger.Get().Warn("Lost the leader, suspend the controller")
			}

1. A is leader, B is follower
2. leader change to B: A lost the leader and suspend(), however the prevTermLeader is still A
3. When A re-get the leadership, since prevTermLeader == c.clusterStore.ID(), it cannot resume the leadership