### PR TITLE
feat(webui): use nextjs middleware to dynamically redirect API calls

### DIFF
--- a/webui/next.config.mjs
+++ b/webui/next.config.mjs
@@ -20,7 +20,7 @@
 const nextConfig = (phase, { defaultConfig }) => {
     return {
         reactStrictMode: true,
-        output: 'standalone',
+        output: "standalone",
     };
 };
 

--- a/webui/next.config.mjs
+++ b/webui/next.config.mjs
@@ -17,25 +17,10 @@
  * under the License.
  */
 
-import { PHASE_DEVELOPMENT_SERVER } from "next/constants.js";
-
-const apiPrefix = "/api/v1";
-const devHost = "127.0.0.1:9379";
-const prodHost = "production-api.yourdomain.com";
-
 const nextConfig = (phase, { defaultConfig }) => {
-    const isDev = phase === PHASE_DEVELOPMENT_SERVER;
-    const host = isDev ? devHost : prodHost;
-
     return {
-        async rewrites() {
-            return [
-                {
-                    source: `${apiPrefix}/:slug*`,
-                    destination: `http://${host}${apiPrefix}/:slug*`,
-                },
-            ];
-        },
+        reactStrictMode: true,
+        output: 'standalone',
     };
 };
 

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,41 +1,46 @@
 {
-    "name": "kvrocks-controller-ui",
-    "version": "0.1.0",
-    "private": true,
-    "scripts": {
-        "dev": "next dev",
-        "build": "next build",
-        "start": "next start",
-        "lint": "next lint"
-    },
-    "dependencies": {
-        "@emotion/react": "^11.11.3",
-        "@emotion/styled": "^11.11.0",
-        "@fortawesome/fontawesome-svg-core": "^6.6.0",
-        "@fortawesome/free-brands-svg-icons": "^6.6.0",
-        "@fortawesome/free-solid-svg-icons": "^6.6.0",
-        "@fortawesome/react-fontawesome": "^0.2.2",
-        "@mui/icons-material": "^5.15.7",
-        "@mui/material": "^5.15.5",
-        "@types/js-yaml": "^4.0.9",
-        "axios": "^1.6.7",
-        "js-yaml": "^4.1.0",
-        "next": "^14.2.29",
-        "react": "^18",
-        "react-dom": "^18"
-    },
-    "devDependencies": {
-        "@types/node": "^20",
-        "@types/react": "^18",
-        "@types/react-dom": "^18",
-        "autoprefixer": "^10.0.1",
-        "eslint": "^8",
-        "eslint-config-next": "14.1.0",
-        "eslint-config-prettier": "^10.1.1",
-        "postcss": "^8",
-        "prettier": "^3.5.3",
-        "prettier-plugin-tailwindcss": "^0.6.11",
-        "tailwindcss": "^3.3.0",
-        "typescript": "^5"
-    }
+  "name": "kvrocks-controller-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "deploy": "next build && cp -r .next/static .next/standalone/.next/ && cp -r public .next/standalone/"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.0",
+    "@fortawesome/fontawesome-svg-core": "^6.6.0",
+    "@fortawesome/free-brands-svg-icons": "^6.6.0",
+    "@fortawesome/free-solid-svg-icons": "^6.6.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
+    "@mui/icons-material": "^5.15.7",
+    "@mui/material": "^5.15.5",
+    "@types/js-yaml": "^4.0.9",
+    "axios": "^1.6.7",
+    "js-yaml": "^4.1.0",
+    "next": "15.5.4",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "19.2.2",
+    "@types/react-dom": "19.2.1",
+    "autoprefixer": "^10.0.1",
+    "eslint": "^8",
+    "eslint-config-next": "15.5.4",
+    "eslint-config-prettier": "^10.1.1",
+    "postcss": "^8",
+    "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.11",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5"
+  },
+  "overrides": {
+    "@types/react": "19.2.2",
+    "@types/react-dom": "19.2.1"
+  }
 }

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "kvrocks-controller-ui",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "deploy": "next build && cp -r .next/static .next/standalone/.next/ && cp -r public .next/standalone/"
-  },
-  "dependencies": {
-    "@emotion/react": "^11.11.3",
-    "@emotion/styled": "^11.11.0",
-    "@fortawesome/fontawesome-svg-core": "^6.6.0",
-    "@fortawesome/free-brands-svg-icons": "^6.6.0",
-    "@fortawesome/free-solid-svg-icons": "^6.6.0",
-    "@fortawesome/react-fontawesome": "^0.2.2",
-    "@mui/icons-material": "^5.15.7",
-    "@mui/material": "^5.15.5",
-    "@types/js-yaml": "^4.0.9",
-    "axios": "^1.6.7",
-    "js-yaml": "^4.1.0",
-    "next": "15.5.4",
-    "react": "19.2.0",
-    "react-dom": "19.2.0"
-  },
-  "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.1",
-    "autoprefixer": "^10.0.1",
-    "eslint": "^8",
-    "eslint-config-next": "15.5.4",
-    "eslint-config-prettier": "^10.1.1",
-    "postcss": "^8",
-    "prettier": "^3.5.3",
-    "prettier-plugin-tailwindcss": "^0.6.11",
-    "tailwindcss": "^3.3.0",
-    "typescript": "^5"
-  },
-  "overrides": {
-    "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.1"
-  }
+    "name": "kvrocks-controller-ui",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev --turbopack",
+        "build": "next build",
+        "start": "next start",
+        "lint": "next lint",
+        "deploy": "next build && cp -r .next/static .next/standalone/.next/ && cp -r public .next/standalone/"
+    },
+    "dependencies": {
+        "@emotion/react": "^11.11.3",
+        "@emotion/styled": "^11.11.0",
+        "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-brands-svg-icons": "^6.6.0",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "@mui/icons-material": "^5.15.7",
+        "@mui/material": "^5.15.5",
+        "@types/js-yaml": "^4.0.9",
+        "axios": "^1.6.7",
+        "js-yaml": "^4.1.0",
+        "next": "15.5.4",
+        "react": "19.2.0",
+        "react-dom": "19.2.0"
+    },
+    "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "19.2.2",
+        "@types/react-dom": "19.2.1",
+        "autoprefixer": "^10.0.1",
+        "eslint": "^8",
+        "eslint-config-next": "15.5.4",
+        "eslint-config-prettier": "^10.1.1",
+        "postcss": "^8",
+        "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.6.11",
+        "tailwindcss": "^3.3.0",
+        "typescript": "^5"
+    },
+    "overrides": {
+        "@types/react": "19.2.2",
+        "@types/react-dom": "19.2.1"
+    }
 }

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx
@@ -38,7 +38,7 @@ import {
     Divider,
 } from "@mui/material";
 import { ClusterSidebar } from "../../../../ui/sidebar";
-import { useState, useEffect } from "react";
+import { useState, useEffect, use } from "react";
 import { listShards, listNodes, fetchCluster, deleteShard } from "@/app/lib/api";
 import { AddShardCard, ResourceCard } from "@/app/ui/createCard";
 import Link from "next/link";
@@ -95,7 +95,8 @@ type FilterOption =
     | "with-importing";
 type SortOption = "index-asc" | "index-desc" | "nodes-desc" | "nodes-asc";
 
-export default function Cluster({ params }: { params: { namespace: string; cluster: string } }) {
+export default function Cluster(props: { params: Promise<{ namespace: string; cluster: string }> }) {
+    const params = use(props.params);
     const { namespace, cluster } = params;
     const [shardsData, setShardsData] = useState<ShardData[]>([]);
     const [resourceCounts, setResourceCounts] = useState<ResourceCounts>({

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/page.tsx
@@ -95,7 +95,9 @@ type FilterOption =
     | "with-importing";
 type SortOption = "index-asc" | "index-desc" | "nodes-desc" | "nodes-asc";
 
-export default function Cluster(props: { params: Promise<{ namespace: string; cluster: string }> }) {
+export default function Cluster(props: {
+    params: Promise<{ namespace: string; cluster: string }>;
+}) {
     const params = use(props.params);
     const { namespace, cluster } = params;
     const [shardsData, setShardsData] = useState<ShardData[]>([]);

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/nodes/[node]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/nodes/[node]/page.tsx
@@ -39,11 +39,9 @@ import NetworkCheckIcon from "@mui/icons-material/NetworkCheck";
 import SecurityIcon from "@mui/icons-material/Security";
 import LinkIcon from "@mui/icons-material/Link";
 
-export default function Node(
-    props: {
-        params: Promise<{ namespace: string; cluster: string; shard: string; node: string }>;
-    }
-) {
+export default function Node(props: {
+    params: Promise<{ namespace: string; cluster: string; shard: string; node: string }>;
+}) {
     const params = use(props.params);
     const { namespace, cluster, shard, node } = params;
     const router = useRouter();

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/nodes/[node]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/nodes/[node]/page.tsx
@@ -22,7 +22,7 @@
 import { listNodes } from "@/app/lib/api";
 import { NodeSidebar } from "@/app/ui/sidebar";
 import { Box, Typography, Chip, Paper, Divider, Grid, Alert, IconButton } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
 import { LoadingSpinner } from "@/app/ui/loadingSpinner";
 import { truncateText } from "@/app/utils";
@@ -39,11 +39,12 @@ import NetworkCheckIcon from "@mui/icons-material/NetworkCheck";
 import SecurityIcon from "@mui/icons-material/Security";
 import LinkIcon from "@mui/icons-material/Link";
 
-export default function Node({
-    params,
-}: {
-    params: { namespace: string; cluster: string; shard: string; node: string };
-}) {
+export default function Node(
+    props: {
+        params: Promise<{ namespace: string; cluster: string; shard: string; node: string }>;
+    }
+) {
+    const params = use(props.params);
     const { namespace, cluster, shard, node } = params;
     const router = useRouter();
     const [nodeData, setNodeData] = useState<any[]>([]);

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/page.tsx
@@ -60,11 +60,9 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import { FailoverDialog } from "@/app/ui/failoverDialog";
 
-export default function Shard(
-    props: {
-        params: Promise<{ namespace: string; cluster: string; shard: string }>;
-    }
-) {
+export default function Shard(props: {
+    params: Promise<{ namespace: string; cluster: string; shard: string }>;
+}) {
     const params = use(props.params);
     const { namespace, cluster, shard } = params;
     const [nodesData, setNodesData] = useState<any>(null);

--- a/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/clusters/[cluster]/shards/[shard]/page.tsx
@@ -37,7 +37,7 @@ import {
 import { ShardSidebar } from "@/app/ui/sidebar";
 import { fetchShard, deleteNode } from "@/app/lib/api";
 import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, use } from "react";
 import { AddNodeCard } from "@/app/ui/createCard";
 import Link from "next/link";
 import { LoadingSpinner } from "@/app/ui/loadingSpinner";
@@ -60,11 +60,12 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import { FailoverDialog } from "@/app/ui/failoverDialog";
 
-export default function Shard({
-    params,
-}: {
-    params: { namespace: string; cluster: string; shard: string };
-}) {
+export default function Shard(
+    props: {
+        params: Promise<{ namespace: string; cluster: string; shard: string }>;
+    }
+) {
+    const params = use(props.params);
     const { namespace, cluster, shard } = params;
     const [nodesData, setNodesData] = useState<any>(null);
     const [loading, setLoading] = useState<boolean>(true);

--- a/webui/src/app/namespaces/[namespace]/page.tsx
+++ b/webui/src/app/namespaces/[namespace]/page.tsx
@@ -45,7 +45,7 @@ import {
 } from "@/app/lib/api";
 import Link from "next/link";
 import { useRouter, notFound } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, use } from "react";
 import { LoadingSpinner } from "@/app/ui/loadingSpinner";
 import StorageIcon from "@mui/icons-material/Storage";
 import FolderIcon from "@mui/icons-material/Folder";
@@ -106,7 +106,8 @@ type SortOption =
     | "nodes-desc"
     | "nodes-asc";
 
-export default function Namespace({ params }: { params: { namespace: string } }) {
+export default function Namespace(props: { params: Promise<{ namespace: string }> }) {
+    const params = use(props.params);
     const [clusterData, setClusterData] = useState<ClusterData[]>([]);
     const [resourceCounts, setResourceCounts] = useState<ResourceCounts>({
         clusters: 0,

--- a/webui/src/app/page.tsx
+++ b/webui/src/app/page.tsx
@@ -60,7 +60,7 @@ export default function Home() {
     const [scrollY, setScrollY] = useState(0);
     const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 });
     const [cursorVisible, setCursorVisible] = useState(true);
-    const requestRef = useRef<number>();
+    const requestRef = useRef<number>(undefined);
     const prevScrollY = useRef(0);
 
     const terminalRef = useRef({ lineIndex: 0, charIndex: 0 });

--- a/webui/src/middleware.ts
+++ b/webui/src/middleware.ts
@@ -2,19 +2,19 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function middleware(req: NextRequest) {
-    const url = req.nextUrl.clone()
+    const url = req.nextUrl.clone();
 
     if (url.pathname.startsWith("/api/v1")) {
-        const host = process.env.KVCTL_API_HOST || "localhost:9379"
+        const host = process.env.KVCTL_API_HOST || "localhost:9379";
         url.host = host;
 
-        return NextResponse.rewrite(url)
+        return NextResponse.rewrite(url);
     }
 
-    return NextResponse.next()
+    return NextResponse.next();
 }
 
 export const config = {
     matcher: "/api/v1/:path*",
-    runtime: 'nodejs',
-}
+    runtime: "nodejs",
+};

--- a/webui/src/middleware.ts
+++ b/webui/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+    const url = req.nextUrl.clone()
+
+    if (url.pathname.startsWith("/api/v1")) {
+        const host = process.env.KVCTL_API_HOST || "localhost:9379"
+        url.host = host;
+
+        return NextResponse.rewrite(url)
+    }
+
+    return NextResponse.next()
+}
+
+export const config = {
+    matcher: "/api/v1/:path*",
+    runtime: 'nodejs',
+}

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -15,43 +15,30 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */{
-  "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+ */ {
+    "compilerOptions": {
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "preserve",
+        "incremental": true,
+        "plugins": [
+            {
+                "name": "next"
+            }
+        ],
+        "paths": {
+            "@/*": ["./src/*"]
+        },
+        "target": "ES2017"
     },
-    "target": "ES2017"
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "exclude": ["node_modules"]
 }

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -15,31 +15,43 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */
-
-{
-    "compilerOptions": {
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "noEmit": true,
-        "esModuleInterop": true,
-        "module": "esnext",
-        "moduleResolution": "bundler",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "jsx": "preserve",
-        "incremental": true,
-        "plugins": [
-            {
-                "name": "next"
-            }
-        ],
-        "paths": {
-            "@/*": ["./src/*"]
-        }
+ */{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-    "exclude": ["node_modules"]
+    "target": "ES2017"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This includes:
- update nextjs from 14 to 15
- remove the URL rewrite function from next config
- add a nextjs nodejs middleware to rewrite URLs dynamically (without rebuild the webui!)
- enable standalone mode
- add an env var KVCTL_API_HOST for running node with dynamic endpoint (server side)