### PR TITLE
Fix unable to promote the new master while sequence=0 during cluster shard failover

### DIFF
--- a/store/cluster_shard.go
+++ b/store/cluster_shard.go
@@ -151,6 +151,18 @@ func (shard *Shard) removeNode(nodeID string) error {
 func (shard *Shard) getNewMasterNodeIndex(ctx context.Context, masterNodeIndex int, preferredNodeID string) int {
 	newMasterNodeIndex := -1
 	var newestOffset uint64
+
+	// Get master sequence to handle empty shard case (issue #366)
+	var masterSequence uint64
+	if masterNodeIndex >= 0 && masterNodeIndex < len(shard.Nodes) {
+		masterNode := shard.Nodes[masterNodeIndex]
+		if _, err := masterNode.GetClusterInfo(ctx); err == nil {
+			if masterInfo, err := masterNode.GetClusterNodeInfo(ctx); err == nil {
+				masterSequence = masterInfo.Sequence
+			}
+		}
+	}
+
 	for i, node := range shard.Nodes {
 		// don't promote the current master node
 		if i == masterNodeIndex {
@@ -176,12 +188,14 @@ func (shard *Shard) getNewMasterNodeIndex(ctx context.Context, masterNodeIndex i
 			).Warn("Skip the node due to failed to get info of node")
 			continue
 		}
-		if clusterNodeInfo.Role != RoleSlave || clusterNodeInfo.Sequence == 0 {
+		// Fix #366: allow sequence == 0 only when master sequence is also 0 (empty shard)
+		if clusterNodeInfo.Role != RoleSlave || (clusterNodeInfo.Sequence == 0 && masterSequence != 0) {
 			logger.Get().With(
 				zap.String("id", node.ID()),
 				zap.String("addr", node.Addr()),
 				zap.String("role", clusterNodeInfo.Role),
 				zap.Uint64("sequence", clusterNodeInfo.Sequence),
+				zap.Uint64("master_sequence", masterSequence),
 			).Warn("Skip the node due to role or sequence invalid")
 			continue
 		}


### PR DESCRIPTION
### Problem
Failover fails when a shard has never received any writes and its sequence number is `0`.
In this case, the validation logic incorrectly rejects the failover even when both the
current master and the new master have a sequence of `0`.

This scenario is reported in issue #366 and can occur for empty or newly created shards.

### Solution
Update the failover validation logic to explicitly allow `sequence == 0` when the
current master’s sequence is also `0`.

This ensures failover works correctly for empty shards without changing behavior
for non-zero sequence cases.

### Scope
- Limited to failover logic
- Single focused change
- No refactors, exports, CI, or unrelated fixes

### Testing
- Existing tests pass
- No behavioral change for non-zero sequences

Fixes #366
