### PR TITLE
Fix #266: Remove duplicate redirect causing JSON unmarshal error on n…

### DIFF
--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -76,7 +76,6 @@ func RedirectIfNotLeader(c *gin.Context) {
 			c.Set(consts.HeaderIsRedirect, true)
 			peerAddr := helper.ExtractAddrFromSessionID(storage.Leader())
 			c.Redirect(http.StatusTemporaryRedirect, "http://"+peerAddr+c.Request.RequestURI)
-			c.Redirect(http.StatusTemporaryRedirect, "http://"+storage.Leader()+c.Request.RequestURI)
 		} else {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no leader now, please retry later"})
 			c.Abort()


### PR DESCRIPTION
## Problem
Issue #266: `kvctl` commands fail with "unexpected end of JSON input" when connecting to non-loopback IP addresses via `-H` flag.

## Root Cause
Duplicate `c.Redirect()` calls in [RedirectIfNotLeader](cci:1://file:///c:/Users/kingk/Desktop/gsoc/apache/%23266/kvrocks-controller/server/middleware/middleware.go:62:0-85:1) middleware (lines 78-79):
- Line 78: Correctly redirects using extracted peer address ✓
- Line 79: Immediately overwrites with raw session ID ✗

This creates an invalid redirect URL causing empty/malformed responses.

## Solution
Remove the duplicate second redirect call (line 79).

## Changes
- 1 line removed from [server/middleware/middleware.go](cci:7://file:///c:/Users/kingk/Desktop/gsoc/apache/%23266/kvrocks-controller/server/middleware/middleware.go:0:0-0:0)
- Minimal, focused fix with no other code changes

Fixes #266