### PR TITLE
Fix(middleware): Prevent infinite redirect loop for self-redirects

### DIFF
--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -69,21 +69,28 @@ func RedirectIfNotLeader(c *gin.Context) {
 	}
 
 	_, isRaftMode := storage.GetEngine().(*raft.Node)
-	// Raft engine will forward the request to the leader node under the hood,
-	// so we don't need to do the redirect.
-	if !storage.IsLeader() && !isRaftMode {
-		if !c.GetBool(consts.HeaderIsRedirect) {
-			c.Set(consts.HeaderIsRedirect, true)
-			peerAddr := helper.ExtractAddrFromSessionID(storage.Leader())
-			c.Redirect(http.StatusTemporaryRedirect, "http://"+peerAddr+c.Request.RequestURI)
-			c.Redirect(http.StatusTemporaryRedirect, "http://"+storage.Leader()+c.Request.RequestURI)
-		} else {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no leader now, please retry later"})
-			c.Abort()
-		}
+	redirect, peerAddr, err := shouldRedirect(storage.IsLeader(), isRaftMode, storage.Leader(), c.Request.Host)
+	if err != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
+		c.Abort()
+		return
+	}
+	if redirect {
+		c.Redirect(http.StatusTemporaryRedirect, "http://"+peerAddr+c.Request.RequestURI)
 		return
 	}
 	c.Next()
+}
+
+func shouldRedirect(isLeader, isRaftMode bool, leaderSessionID, requestHost string) (bool, string, error) {
+	if isLeader || isRaftMode {
+		return false, "", nil
+	}
+	peerAddr := helper.ExtractAddrFromSessionID(leaderSessionID)
+	if peerAddr == requestHost {
+		return false, "", errors.New("leader is self but not active, please retry later")
+	}
+	return true, peerAddr, nil
 }
 
 func RequiredNamespace(c *gin.Context) {

--- a/server/middleware/middleware_test.go
+++ b/server/middleware/middleware_test.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/apache/kvrocks-controller/server/helper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldRedirect(t *testing.T) {
+	tests := []struct {
+		name            string
+		isLeader        bool
+		isRaftMode      bool
+		leaderSessionID string
+		requestHost     string
+		expectRedirect  bool
+		expectAddr      string
+		expectError     bool
+	}{
+		{
+			name:           "Is leader",
+			isLeader:       true,
+			isRaftMode:     false,
+			expectRedirect: false,
+		},
+		{
+			name:           "Is raft mode",
+			isLeader:       false,
+			isRaftMode:     true,
+			expectRedirect: false,
+		},
+		{
+			name:            "Not leader, not raft, valid peer",
+			isLeader:        false,
+			isRaftMode:      false,
+			leaderSessionID: "127.0.0.1:9379",
+			requestHost:     "127.0.0.1:1234",
+			expectRedirect:  true,
+			expectAddr:      "127.0.0.1:9379",
+			expectError:     false,
+		},
+		{
+			name:            "Not leader, not raft, self redirect detected",
+			isLeader:        false,
+			isRaftMode:      false,
+			leaderSessionID: "127.0.0.1:9379",
+			requestHost:     "127.0.0.1:9379",
+			expectRedirect:  false,
+			expectError:     true,
+		},
+		{
+			name:            "Not leader, not raft, valid peer with random session",
+			isLeader:        false,
+			isRaftMode:      false,
+			leaderSessionID: helper.GenerateSessionID("127.0.0.1:9379"),
+			requestHost:     "127.0.0.1:1234",
+			expectRedirect:  true,
+			expectAddr:      "127.0.0.1:9379",
+			expectError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redirect, addr, err := shouldRedirect(tt.isLeader, tt.isRaftMode, tt.leaderSessionID, tt.requestHost)
+			assert.Equal(t, tt.expectRedirect, redirect)
+			if tt.expectRedirect {
+				assert.Equal(t, tt.expectAddr, addr)
+				assert.NoError(t, err)
+			} else if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor RedirectIfNotLeader middleware to include explicit checks for self-redirect scenarios. When a node is not leader but the leader address points to itself, the middleware now returns a 503 error instead of attempting redirect, breaking the loop. Includes unit tests covering self-redirect cases and other redirect scenarios.

Fixes #302